### PR TITLE
feat(http): add API key middleware for protected routes

### DIFF
--- a/internal/transport/http/v1.go
+++ b/internal/transport/http/v1.go
@@ -11,6 +11,7 @@ import (
 func loadV1Routes(r *gin.Engine, h *handler.Handler, appConfig *config.AppConfig, logger *logger.Logger) {
 	v1 := r.Group("/api/v1")
 
+	// Oracle routes (require API key)
 	oracle := v1.Group("/oracle")
 	{
 		oracle.GET("/circulated-icy", h.OracleHandler.GetCirculatedICY)
@@ -19,12 +20,13 @@ func loadV1Routes(r *gin.Engine, h *handler.Handler, appConfig *config.AppConfig
 		oracle.GET("/icy-btc-ratio-cached", h.OracleHandler.GetICYBTCRatioCached)
 	}
 
+	// Swap routes (require API key)
 	swap := v1.Group("/swap")
 	{
 		swap.POST("", h.SwapHandler.TriggerSwap)
 	}
 
-	// health check
+	// health check (no API key required)
 	r.GET("/healthz", func(c *gin.Context) {
 		c.JSON(200, gin.H{
 			"message": "ok",

--- a/internal/utils/config/config.go
+++ b/internal/utils/config/config.go
@@ -21,6 +21,7 @@ type AppConfig struct {
 
 type ApiServerConfig struct {
 	AllowedOrigins string
+	ApiKey         string
 }
 
 type BlockchainConfig struct {
@@ -57,6 +58,7 @@ func New() *AppConfig {
 	return &AppConfig{
 		ApiServer: ApiServerConfig{
 			AllowedOrigins: os.Getenv("ALLOWED_ORIGINS"),
+			ApiKey:         os.Getenv("API_KEY"),
 		},
 		Postgres: DBConnection{
 			Host:    os.Getenv("DB_HOST"),


### PR DESCRIPTION
#### What's this PR do?

- [x] Add middleware to check Header `Authorization: ApiKey abc`

#### Any background context you want to provide? (if appropriate)

Production would be deployed outside the DF system. To verify valid requests, we need to check the request header to verify requests with a valid API key.