### PR TITLE
feat(broadcast): add fee adjustment for transaction broadcasting

### DIFF
--- a/internal/btcrpc/blockstream/interface.go
+++ b/internal/btcrpc/blockstream/interface.go
@@ -2,6 +2,18 @@ package blockstream
 
 import "github.com/dwarvesf/icy-backend/internal/model"
 
+// BroadcastTxError represents a detailed error when broadcasting a transaction
+type BroadcastTxError struct {
+	Message    string
+	StatusCode int
+	MinFee     int64 // Minimum fee required in satoshis
+}
+
+// Error implements the error interface
+func (e *BroadcastTxError) Error() string {
+	return e.Message
+}
+
 type IBlockStream interface {
 	BroadcastTx(txHex string) (hash string, err error)
 	EstimateFees() (fees map[string]float64, err error)

--- a/internal/handler/swap/swap.go
+++ b/internal/handler/swap/swap.go
@@ -91,7 +91,7 @@ func (h *handler) CreateSwapRequest(c *gin.Context) {
 		return
 	}
 	if icyAmountFloat < h.appConfig.MinIcySwapAmount {
-		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, fmt.Errorf("minimum ICY amount is %s", h.appConfig.MinIcySwapAmount), nil, "invalid ICY amount"))
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, fmt.Errorf("minimum ICY amount is %v", h.appConfig.MinIcySwapAmount), nil, "invalid ICY amount"))
 		return
 	}
 


### PR DESCRIPTION
#### What's this PR do?

- [x] Add a retry mechanism to recalculate the Bitcoin fee if there’s a rejection due to a fee reason.

#### Any background context you want to provide? (if appropriate)

- The Bitcoin chain sometimes rejects our sending request because the estimated fee is less than the minimum fee. To address this issue, I’ve added more logic to use the minimum fee if it’s not more than 5% of the total amount being sent, in order to compare it with the estimated fee.
