### PR TITLE
refactor(baserpc): improve transaction address handling and logging

### DIFF
--- a/internal/telemetry/swap.go
+++ b/internal/telemetry/swap.go
@@ -22,6 +22,15 @@ func (t *Telemetry) ProcessSwapRequests() error {
 	}
 
 	for _, req := range pendingSwapRequests {
+		// validate icy tx
+		_, err := t.store.OnchainIcyTransaction.GetByTransactionHash(t.db, req.IcyTx)
+		if err != nil {
+			t.logger.Error("[ProcessSwapRequests][GetIcyTx]", map[string]string{
+				"error":   err.Error(),
+				"tx_hash": req.IcyTx,
+			})
+			continue
+		}
 		// Validate BTC address
 		if err := t.validateBTCAddress(req.BTCAddress); err != nil {
 			t.logger.Error("[ProcessSwapRequests][ValidateBTCAddress]", map[string]string{

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"sync"
+
 	"gorm.io/gorm"
 
 	"github.com/dwarvesf/icy-backend/internal/baserpc"
@@ -19,6 +21,9 @@ type Telemetry struct {
 	btcRpc    btcrpc.IBtcRpc
 	baseRpc   baserpc.IBaseRPC
 	oracle    oracle.IOracle
+
+	indexIcyTransactionMutex sync.Mutex
+	indexBtcTransactionMutex sync.Mutex
 }
 
 func New(


### PR DESCRIPTION
#### What's this PR do?

- [x] Add a mutex lock to ensure that only one index process can access the index at a time.
- [x] Add a check to verify that the icy tx has been transferred on the chain before the swap is processed.

#### Any background context you want to provide? (if appropriate)

- Currently, indexing processes are run for every cronjob triggered after an interval loop, which can cause overlap when fetching transactions on the chain between different processes. To address this issue, we need to add a lock to prevent an index process from being triggered to perform another indexing operation before it’s completed.
