### PR TITLE
feat(btcrpc): add caching for Satoshi/USD price retrieval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -304,6 +304,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pion/dtls/v2 v2.2.7 h1:cSUBsETxepsCSFSxC3mc/aDo14qQLMSL+O6IjG28yV8=

--- a/internal/baserpc/baserpc.go
+++ b/internal/baserpc/baserpc.go
@@ -201,10 +201,6 @@ func (b *BaseRPC) GetTransactionsByAddress(address string, fromTxId string) ([]m
 			block, err := b.erc20Service.client.BlockByNumber(context.Background(), big.NewInt(int64(event.Raw.BlockNumber)))
 			if err == nil {
 				transaction.BlockTime = int64(block.Time())
-			} else {
-				b.logger.Error("[GetTransactionsByAddress][BlockByNumber] cannot get block data", map[string]string{
-					"error": err.Error(),
-				})
 			}
 
 			transactions = append(transactions, transaction)

--- a/internal/btcrpc/btcrpc.go
+++ b/internal/btcrpc/btcrpc.go
@@ -3,10 +3,12 @@ package btcrpc
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/patrickmn/go-cache"
 
 	"github.com/dwarvesf/icy-backend/internal/btcrpc/blockstream"
 	"github.com/dwarvesf/icy-backend/internal/model"
@@ -23,6 +25,7 @@ type BtcRpc struct {
 	appConfig   *config.AppConfig
 	logger      *logger.Logger
 	blockstream blockstream.IBlockStream
+	cch         *cache.Cache
 }
 
 func New(appConfig *config.AppConfig, logger *logger.Logger) IBtcRpc {
@@ -30,6 +33,7 @@ func New(appConfig *config.AppConfig, logger *logger.Logger) IBtcRpc {
 		appConfig:   appConfig,
 		logger:      logger,
 		blockstream: blockstream.New(appConfig, logger),
+		cch:         cache.New(1*time.Minute, 2*time.Minute),
 	}
 }
 

--- a/internal/utils/config/config.go
+++ b/internal/utils/config/config.go
@@ -47,6 +47,7 @@ type DBConnection struct {
 type BitcoinConfig struct {
 	WalletWIF         string
 	BlockstreamAPIURL string
+	MaxTxFeeUSD       float64
 }
 
 func New() *AppConfig {
@@ -73,6 +74,7 @@ func New() *AppConfig {
 		Bitcoin: BitcoinConfig{
 			WalletWIF:         os.Getenv("BTC_WALLET_WIF"),
 			BlockstreamAPIURL: os.Getenv("BTC_BLOCKSTREAM_API_URL"),
+			MaxTxFeeUSD:       envVarAsFloat("BTC_MAX_TX_FEE_USD", 1.0),
 		},
 		Blockchain: BlockchainConfig{
 			BaseRPCEndpoint:           os.Getenv("BLOCKCHAIN_BASE_RPC_ENDPOINT"),


### PR DESCRIPTION
#### What's this PR do?

- [x] add cache in memory for btc fee

#### Any background context you want to provide? (if appropriate)

Bitcoin estimation fee needs to be converted to USD so that we can determine if it’s less than $1 for processing. To achieve this, we’ll fetch the satoshi/USD rate from Coingecko. To avoid exceeding the limit threshold set by Coingecko, we’ll employ caching to reduce the number of requests below 60 calls per minute.