### PR TITLE
fix(swap): track swap-request status so Flow B settles once

### DIFF
--- a/docs/verification/flowb-status.md
+++ b/docs/verification/flowb-status.md
@@ -1,0 +1,47 @@
+# Proof of done, Flow-B swap-request status tracking
+
+icy-swap-hardening SG-04 / DF-75. Closes CRIT-2 (repeated BTC payout: `ProcessSwapRequests` never advanced status, so every cron tick re-swapped the same request with a fresh nonce and the on-chain replay guard could not dedupe).
+
+## Acceptance criteria
+
+| # | Criterion | Result |
+|---|---|---|
+| 1 | A settled swap_request is never re-processed on a later tick | PASS |
+| 2 | Status advances pending → processing (claim) → completed / failed | PASS |
+| 3 | A failed swap is marked `failed` (terminal), not silently retried | PASS |
+| 4 | The nonce is deterministic per request (retry reuses it) | PASS |
+
+## Implementation
+
+- `internal/model/swap_request.go`: added `Processing` and `Failed` status constants.
+- `internal/telemetry/swap.go` `ProcessSwapRequests`: claims the row (`pending → processing` via `UpdateStatus`) immediately before the on-chain `Swap`, then settles `completed`/`failed`. Transient pre-swap validation failures still leave it `pending` (retry preserved). Nonce = `keccak256(icyTx)` via `deriveSwapNonce`, replacing the time-based nonce.
+- `internal/baserpc/{interface,baserpc}.go`: `Swap()` takes a `nonce *big.Int` (falls back to time-based if nil).
+- `internal/monitoring/circuit_breaker.go`: forwards the nonce through the wrapper.
+- Commit `a484346`.
+
+Deliberate deviation: the on-chain RPC is NOT wrapped in a SQL transaction (holding a DB tx across a network call is an anti-pattern); the claim-write commits atomically just before the swap and the settle-write just after, still guaranteeing a settled request is never re-picked.
+
+## Recorded run (gate format)
+
+Command: go build ./...
+Exit: 0
+
+Command: go test ./internal/telemetry/... -count=1 -v   (isolated; the pre-existing broken sibling test file set aside)
+Exit: 0
+Output: 4 specs PASS, settles a pending request at most once across two ProcessSwapRequests() calls; never touches processing/completed/failed rows; marks failed swaps failed (terminal); reuses the nonce across a manual retry.
+
+NEGATIVE CONTROL: stripping the status-claim logic (keeping the test file) → 1 Passed, 3 FAILED, exactly the three specs that assert the CRIT-2 fix (at-most-once, failed-terminal, nonce-reuse). Verdict: PASS.
+
+Pre-existing (not from this change): `internal/telemetry/btc_multi_endpoint_test.go` fails to compile on the clean base `ff49a48` (confirmed byte-identical via `cmp`); it is excluded from the run above and was not touched.
+
+## Reproduce
+
+```
+git checkout fix/flowb-status
+export PATH=$HOME/.local/share/mise/installs/go/1.24.2/bin:$PATH GOROOT=$HOME/.local/share/mise/installs/go/1.24.2
+go test ./internal/telemetry/... -count=1   # with the pre-existing broken sibling file set aside
+```
+
+## Rollback
+
+`git revert a484346`, source-only (plus a new status constant), no migration/data change. Reverting restores prior behavior. Residual to note: nonce is deterministic but `deadline` is still fresh per attempt, so full replay-guard determinism across arbitrary-time retries is not achieved (flagged for review; the bug report only flagged the nonce).

--- a/internal/baserpc/baserpc.go
+++ b/internal/baserpc/baserpc.go
@@ -780,9 +780,16 @@ func (b *BaseRPC) Swap(
 	icyAmount *model.Web3BigInt,
 	btcAddress string,
 	btcAmount *model.Web3BigInt,
+	nonce *big.Int,
 ) (*types.Transaction, error) {
-	// Generate a nonce and a deadline
-	nonce := big.NewInt(time.Now().UnixNano())
+	// The caller (ProcessSwapRequests) derives a nonce deterministically from
+	// the swap request so a retried/re-queued request reuses the same nonce
+	// instead of minting a fresh one every attempt (CRIT-2: the on-chain
+	// swappedHashes replay guard can only dedupe when the nonce is stable).
+	// Fall back to a time-based nonce only for callers that don't supply one.
+	if nonce == nil {
+		nonce = big.NewInt(time.Now().UnixNano())
+	}
 	deadline := big.NewInt(time.Now().Add(10 * time.Minute).Unix())
 
 	signature, err := b.GenerateSignature(icyAmount, btcAddress, btcAmount, nonce, deadline)

--- a/internal/baserpc/interface.go
+++ b/internal/baserpc/interface.go
@@ -20,6 +20,7 @@ type IBaseRPC interface {
 		icyAmount *model.Web3BigInt,
 		btcAddress string,
 		btcAmount *model.Web3BigInt,
+		nonce *big.Int,
 	) (*types.Transaction, error)
 	GenerateSignature(
 		icyAmount *model.Web3BigInt,

--- a/internal/model/swap_request.go
+++ b/internal/model/swap_request.go
@@ -9,8 +9,10 @@ import (
 type SwapRequestStatus string
 
 const (
-	SwapRequestStatusPending   SwapRequestStatus = "pending"
-	SwapRequestStatusCompleted SwapRequestStatus = "completed"
+	SwapRequestStatusPending    SwapRequestStatus = "pending"
+	SwapRequestStatusProcessing SwapRequestStatus = "processing"
+	SwapRequestStatusCompleted  SwapRequestStatus = "completed"
+	SwapRequestStatusFailed     SwapRequestStatus = "failed"
 )
 
 type SwapRequest struct {

--- a/internal/monitoring/circuit_breaker.go
+++ b/internal/monitoring/circuit_breaker.go
@@ -112,7 +112,7 @@ func NewCircuitBreakerBaseRPCWithTimeout(wrapped baserpc.IBaseRPC, config Circui
 // executeWithTimeout executes a function with timeout and metrics recording
 func (cb *CircuitBreakerBtcRPC) executeWithTimeout(operation string, fn func() (interface{}, error)) (interface{}, error) {
 	start := time.Now()
-	
+
 	// Determine timeout based on operation type
 	var timeout time.Duration
 	switch operation {
@@ -121,19 +121,19 @@ func (cb *CircuitBreakerBtcRPC) executeWithTimeout(operation string, fn func() (
 	default:
 		timeout = cb.timeoutConfig.RequestTimeout
 	}
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	
+
 	done := make(chan struct{})
 	var result interface{}
 	var err error
-	
+
 	go func() {
 		defer close(done)
 		result, err = fn()
 	}()
-	
+
 	select {
 	case <-done:
 		duration := time.Since(start).Seconds()
@@ -144,7 +144,7 @@ func (cb *CircuitBreakerBtcRPC) executeWithTimeout(operation string, fn func() (
 		}
 		cb.metrics.RecordAPICall("btc_rpc", operation, status, duration)
 		return result, err
-		
+
 	case <-ctx.Done():
 		cb.metrics.RecordTimeout("btc_rpc", operation)
 		cb.logError("btc_rpc", operation, time.Since(start).Seconds(), ctx.Err())
@@ -155,7 +155,7 @@ func (cb *CircuitBreakerBtcRPC) executeWithTimeout(operation string, fn func() (
 // executeWithTimeoutBase executes a function with timeout and metrics recording for Base RPC
 func (cb *CircuitBreakerBaseRPC) executeWithTimeout(operation string, fn func() (interface{}, error)) (interface{}, error) {
 	start := time.Now()
-	
+
 	// Determine timeout based on operation type
 	var timeout time.Duration
 	switch operation {
@@ -164,19 +164,19 @@ func (cb *CircuitBreakerBaseRPC) executeWithTimeout(operation string, fn func() 
 	default:
 		timeout = cb.timeoutConfig.RequestTimeout
 	}
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	
+
 	done := make(chan struct{})
 	var result interface{}
 	var err error
-	
+
 	go func() {
 		defer close(done)
 		result, err = fn()
 	}()
-	
+
 	select {
 	case <-done:
 		duration := time.Since(start).Seconds()
@@ -187,7 +187,7 @@ func (cb *CircuitBreakerBaseRPC) executeWithTimeout(operation string, fn func() 
 		}
 		cb.metrics.RecordAPICall("base_rpc", operation, status, duration)
 		return result, err
-		
+
 	case <-ctx.Done():
 		cb.metrics.RecordTimeout("base_rpc", operation)
 		cb.logError("base_rpc", operation, time.Since(start).Seconds(), ctx.Err())
@@ -210,11 +210,11 @@ func (cb *CircuitBreakerBtcRPC) Send(receiverAddress string, amount *model.Web3B
 			}, nil
 		})
 	})
-	
+
 	if err != nil {
 		return "", 0, err
 	}
-	
+
 	resultMap := result.(map[string]interface{})
 	return resultMap["txHash"].(string), resultMap["fee"].(int64), nil
 }
@@ -225,11 +225,11 @@ func (cb *CircuitBreakerBtcRPC) CurrentBalance() (*model.Web3BigInt, error) {
 			return cb.wrapped.CurrentBalance()
 		})
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return result.(*model.Web3BigInt), nil
 }
 
@@ -239,11 +239,11 @@ func (cb *CircuitBreakerBtcRPC) GetTransactionsByAddress(address string, fromTxI
 			return cb.wrapped.GetTransactionsByAddress(address, fromTxId)
 		})
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return result.([]model.OnchainBtcTransaction), nil
 }
 
@@ -253,11 +253,11 @@ func (cb *CircuitBreakerBtcRPC) EstimateFees() (map[string]float64, error) {
 			return cb.wrapped.EstimateFees()
 		})
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return result.(map[string]float64), nil
 }
 
@@ -267,11 +267,11 @@ func (cb *CircuitBreakerBtcRPC) GetSatoshiUSDPrice() (float64, error) {
 			return cb.wrapped.GetSatoshiUSDPrice()
 		})
 	})
-	
+
 	if err != nil {
 		return 0, err
 	}
-	
+
 	return result.(float64), nil
 }
 
@@ -295,11 +295,11 @@ func (cb *CircuitBreakerBaseRPC) ICYBalanceOf(address string) (*model.Web3BigInt
 			return cb.wrapped.ICYBalanceOf(address)
 		})
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return result.(*model.Web3BigInt), nil
 }
 
@@ -309,11 +309,11 @@ func (cb *CircuitBreakerBaseRPC) ICYTotalSupply() (*model.Web3BigInt, error) {
 			return cb.wrapped.ICYTotalSupply()
 		})
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return result.(*model.Web3BigInt), nil
 }
 
@@ -323,25 +323,25 @@ func (cb *CircuitBreakerBaseRPC) GetTransactionsByAddress(address string, fromTx
 			return cb.wrapped.GetTransactionsByAddress(address, fromTxId)
 		})
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return result.([]model.OnchainIcyTransaction), nil
 }
 
-func (cb *CircuitBreakerBaseRPC) Swap(icyAmount *model.Web3BigInt, btcAddress string, btcAmount *model.Web3BigInt) (*types.Transaction, error) {
+func (cb *CircuitBreakerBaseRPC) Swap(icyAmount *model.Web3BigInt, btcAddress string, btcAmount *model.Web3BigInt, nonce *big.Int) (*types.Transaction, error) {
 	result, err := cb.circuitBreaker.Execute(func() (interface{}, error) {
 		return cb.executeWithTimeout("swap", func() (interface{}, error) {
-			return cb.wrapped.Swap(icyAmount, btcAddress, btcAmount)
+			return cb.wrapped.Swap(icyAmount, btcAddress, btcAmount, nonce)
 		})
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return result.(*types.Transaction), nil
 }
 
@@ -351,11 +351,11 @@ func (cb *CircuitBreakerBaseRPC) GenerateSignature(icyAmount *model.Web3BigInt, 
 			return cb.wrapped.GenerateSignature(icyAmount, btcAddress, btcAmount, nonce, deadline)
 		})
 	})
-	
+
 	if err != nil {
 		return "", err
 	}
-	
+
 	return result.(string), nil
 }
 
@@ -388,50 +388,50 @@ func classifyError(err error) APIErrorType {
 	if err == nil {
 		return ""
 	}
-	
+
 	errMsg := strings.ToLower(err.Error())
-	
+
 	// Timeout errors
-	if strings.Contains(errMsg, "timeout") || 
-	   strings.Contains(errMsg, "deadline exceeded") ||
-	   strings.Contains(errMsg, "context canceled") {
+	if strings.Contains(errMsg, "timeout") ||
+		strings.Contains(errMsg, "deadline exceeded") ||
+		strings.Contains(errMsg, "context canceled") {
 		return ErrorTypeTimeout
 	}
-	
+
 	// Network errors
 	if strings.Contains(errMsg, "network") ||
-	   strings.Contains(errMsg, "connection") ||
-	   strings.Contains(errMsg, "unreachable") ||
-	   strings.Contains(errMsg, "dns") {
+		strings.Contains(errMsg, "connection") ||
+		strings.Contains(errMsg, "unreachable") ||
+		strings.Contains(errMsg, "dns") {
 		return ErrorTypeNetworkError
 	}
-	
+
 	// Server errors (5xx)
 	if strings.Contains(errMsg, "500") ||
-	   strings.Contains(errMsg, "502") ||
-	   strings.Contains(errMsg, "503") ||
-	   strings.Contains(errMsg, "504") ||
-	   strings.Contains(errMsg, "internal server error") ||
-	   strings.Contains(errMsg, "bad gateway") ||
-	   strings.Contains(errMsg, "service unavailable") ||
-	   strings.Contains(errMsg, "gateway timeout") {
+		strings.Contains(errMsg, "502") ||
+		strings.Contains(errMsg, "503") ||
+		strings.Contains(errMsg, "504") ||
+		strings.Contains(errMsg, "internal server error") ||
+		strings.Contains(errMsg, "bad gateway") ||
+		strings.Contains(errMsg, "service unavailable") ||
+		strings.Contains(errMsg, "gateway timeout") {
 		return ErrorTypeServerError
 	}
-	
+
 	// Client errors (4xx)
 	if strings.Contains(errMsg, "400") ||
-	   strings.Contains(errMsg, "401") ||
-	   strings.Contains(errMsg, "403") ||
-	   strings.Contains(errMsg, "404") ||
-	   strings.Contains(errMsg, "429") ||
-	   strings.Contains(errMsg, "bad request") ||
-	   strings.Contains(errMsg, "unauthorized") ||
-	   strings.Contains(errMsg, "forbidden") ||
-	   strings.Contains(errMsg, "not found") ||
-	   strings.Contains(errMsg, "rate limit") {
+		strings.Contains(errMsg, "401") ||
+		strings.Contains(errMsg, "403") ||
+		strings.Contains(errMsg, "404") ||
+		strings.Contains(errMsg, "429") ||
+		strings.Contains(errMsg, "bad request") ||
+		strings.Contains(errMsg, "unauthorized") ||
+		strings.Contains(errMsg, "forbidden") ||
+		strings.Contains(errMsg, "not found") ||
+		strings.Contains(errMsg, "rate limit") {
 		return ErrorTypeClientError
 	}
-	
+
 	return ErrorTypeUnknown
 }
 
@@ -440,18 +440,18 @@ func validateCircuitBreakerConfig(config CircuitBreakerConfig) error {
 	if config.MaxRequests == 0 {
 		return fmt.Errorf("max_requests must be greater than 0")
 	}
-	
+
 	if config.ConsecutiveFailureThreshold <= 0 {
 		return fmt.Errorf("consecutive_failure_threshold must be greater than 0")
 	}
-	
+
 	if config.Timeout < 0 {
 		return fmt.Errorf("timeout must be non-negative")
 	}
-	
+
 	if config.Interval < 0 {
 		return fmt.Errorf("interval must be non-negative")
 	}
-	
+
 	return nil
 }

--- a/internal/telemetry/swap.go
+++ b/internal/telemetry/swap.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"gorm.io/gorm"
 
 	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
@@ -292,8 +293,30 @@ func (t *Telemetry) ProcessSwapRequests() error {
 			Decimal: consts.BTC_DECIMALS,
 		}
 
+		// Claim the request right before the irreversible on-chain call, not
+		// earlier: the validation steps above are safe to retry on the next
+		// tick (e.g. indexer lag), but re-issuing the swap itself is not.
+		// Moving the row out of 'pending' here means a crash or slow settle
+		// write can never leave it eligible for FindPendingSwapRequests to
+		// pick up again (CRIT-2: repeated payout on every cron tick).
+		if err := t.store.SwapRequest.UpdateStatus(t.db, req.IcyTx, string(model.SwapRequestStatusProcessing)); err != nil {
+			t.logger.Error("[ProcessSwapRequests][ClaimRequest]", map[string]string{
+				"error":   err.Error(),
+				"tx_hash": req.IcyTx,
+			})
+			continue
+		}
+
+		// Nonce is derived deterministically from the immutable ICY deposit
+		// tx hash instead of time.Now().UnixNano(): the same request always
+		// produces the same nonce, so if this request is ever legitimately
+		// re-queued (status manually reset to 'pending' after a 'failed'
+		// settle), the contract's swappedHashes replay guard can actually
+		// dedupe a duplicate on-chain submission.
+		nonce := deriveSwapNonce(req.IcyTx)
+
 		// Trigger swap
-		_, err = t.baseRpc.Swap(icyAmount, req.BTCAddress, satAmount)
+		_, err = t.baseRpc.Swap(icyAmount, req.BTCAddress, satAmount, nonce)
 		if err != nil {
 			t.logger.Error("[ProcessSwapRequests][Swap]", map[string]string{
 				"error":        err.Error(),
@@ -301,11 +324,31 @@ func (t *Telemetry) ProcessSwapRequests() error {
 				"btc_address":  req.BTCAddress,
 				"latest_price": latestPrice.Value,
 			})
+			if failErr := t.store.SwapRequest.UpdateStatus(t.db, req.IcyTx, string(model.SwapRequestStatusFailed)); failErr != nil {
+				t.logger.Error("[ProcessSwapRequests][MarkFailed]", map[string]string{
+					"error":   failErr.Error(),
+					"tx_hash": req.IcyTx,
+				})
+			}
 			continue
+		}
+
+		if err := t.store.SwapRequest.UpdateStatus(t.db, req.IcyTx, string(model.SwapRequestStatusCompleted)); err != nil {
+			t.logger.Error("[ProcessSwapRequests][MarkCompleted]", map[string]string{
+				"error":   err.Error(),
+				"tx_hash": req.IcyTx,
+			})
 		}
 	}
 
 	return nil
+}
+
+// deriveSwapNonce derives a deterministic EIP-712 nonce from a swap
+// request's ICY deposit tx hash, so repeated attempts for the same request
+// always produce the same nonce (see the comment at the Swap call site).
+func deriveSwapNonce(icyTx string) *big.Int {
+	return new(big.Int).SetBytes(crypto.Keccak256([]byte(icyTx)))
 }
 
 // validateBTCAddress validates the format of a BTC address

--- a/internal/telemetry/swap_status_test.go
+++ b/internal/telemetry/swap_status_test.go
@@ -1,0 +1,282 @@
+package telemetry_test
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+
+	"github.com/dwarvesf/icy-backend/internal/model"
+	"github.com/dwarvesf/icy-backend/internal/oracle"
+	"github.com/dwarvesf/icy-backend/internal/store"
+	"github.com/dwarvesf/icy-backend/internal/telemetry"
+	"github.com/dwarvesf/icy-backend/internal/types/environments"
+	"github.com/dwarvesf/icy-backend/internal/utils/config"
+	"github.com/dwarvesf/icy-backend/internal/utils/logger"
+)
+
+// --- fakeSwapRequestStore -------------------------------------------------
+//
+// An in-memory double for swaprequest.IStore that mirrors the real store's
+// `WHERE status = 'pending'` filter in FindPendingSwapRequests. This is what
+// makes the regression test meaningful: calling ProcessSwapRequests twice
+// against the same fake behaves like two real cron ticks against the same
+// Postgres row.
+
+type fakeSwapRequestStore struct {
+	mu       sync.Mutex
+	requests map[string]*model.SwapRequest // keyed by IcyTx
+}
+
+func newFakeSwapRequestStore(reqs ...*model.SwapRequest) *fakeSwapRequestStore {
+	m := map[string]*model.SwapRequest{}
+	for _, r := range reqs {
+		m[r.IcyTx] = r
+	}
+	return &fakeSwapRequestStore{requests: m}
+}
+
+func (f *fakeSwapRequestStore) Create(tx *gorm.DB, swapRequest *model.SwapRequest) (*model.SwapRequest, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests[swapRequest.IcyTx] = swapRequest
+	return swapRequest, nil
+}
+
+func (f *fakeSwapRequestStore) GetByIcyTx(tx *gorm.DB, icyTx string) (*model.SwapRequest, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.requests[icyTx]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return r, nil
+}
+
+func (f *fakeSwapRequestStore) FindPendingSwapRequests(tx *gorm.DB) ([]model.SwapRequest, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []model.SwapRequest
+	for _, r := range f.requests {
+		if r.Status == model.SwapRequestStatusPending {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeSwapRequestStore) UpdateStatus(tx *gorm.DB, icyTx, status string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.requests[icyTx]
+	if !ok {
+		return gorm.ErrRecordNotFound
+	}
+	r.Status = model.SwapRequestStatus(status)
+	return nil
+}
+
+func (f *fakeSwapRequestStore) statusOf(icyTx string) model.SwapRequestStatus {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.requests[icyTx].Status
+}
+
+// --- stubOnchainIcyTxStore ------------------------------------------------
+// ProcessSwapRequests only needs GetByTransactionHash to succeed so the loop
+// reaches the swap step; the other methods are unused by this code path.
+
+type stubOnchainIcyTxStore struct{}
+
+func (s *stubOnchainIcyTxStore) Create(db *gorm.DB, t *model.OnchainIcyTransaction) (*model.OnchainIcyTransaction, error) {
+	return t, nil
+}
+
+func (s *stubOnchainIcyTxStore) GetLatestTransaction(db *gorm.DB) (*model.OnchainIcyTransaction, error) {
+	return nil, nil
+}
+
+func (s *stubOnchainIcyTxStore) GetByTransactionHash(db *gorm.DB, txHash string) (*model.OnchainIcyTransaction, error) {
+	return &model.OnchainIcyTransaction{TransactionHash: txHash}, nil
+}
+
+// --- stubBaseRPC -----------------------------------------------------------
+// Records every Swap() invocation (and the nonce it was called with) so
+// tests can assert both "called at most once" and "same nonce on retry".
+
+type stubBaseRPC struct {
+	mu      sync.Mutex
+	nonces  []*big.Int
+	swapErr error
+}
+
+func (s *stubBaseRPC) Client() *ethclient.Client          { return nil }
+func (s *stubBaseRPC) GetContractAddress() common.Address { return common.Address{} }
+
+func (s *stubBaseRPC) ICYBalanceOf(address string) (*model.Web3BigInt, error) { return nil, nil }
+func (s *stubBaseRPC) ICYTotalSupply() (*model.Web3BigInt, error)             { return nil, nil }
+
+func (s *stubBaseRPC) GetTransactionsByAddress(address string, fromTxId string) ([]model.OnchainIcyTransaction, error) {
+	return nil, nil
+}
+
+func (s *stubBaseRPC) GenerateSignature(icyAmount *model.Web3BigInt, btcAddress string, btcAmount *model.Web3BigInt, nonce *big.Int, deadline *big.Int) (string, error) {
+	return "", nil
+}
+
+func (s *stubBaseRPC) Swap(icyAmount *model.Web3BigInt, btcAddress string, btcAmount *model.Web3BigInt, nonce *big.Int) (*types.Transaction, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nonces = append(s.nonces, new(big.Int).Set(nonce))
+	if s.swapErr != nil {
+		return nil, s.swapErr
+	}
+	return &types.Transaction{}, nil
+}
+
+func (s *stubBaseRPC) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.nonces)
+}
+
+// --- stubOracle --------------------------------------------------------
+// Only GetRealtimeICYBTC is exercised by ProcessSwapRequests; every other
+// method just needs to exist to satisfy oracle.IOracle.
+
+type stubOracle struct {
+	price *model.Web3BigInt
+}
+
+func (s *stubOracle) GetCirculatedICY() (*model.Web3BigInt, error)  { return nil, nil }
+func (s *stubOracle) GetBTCSupply() (*model.Web3BigInt, error)      { return nil, nil }
+func (s *stubOracle) GetRealtimeICYBTC() (*model.Web3BigInt, error) { return s.price, nil }
+func (s *stubOracle) GetCachedRealtimeICYBTC() (*model.Web3BigInt, error) {
+	return s.price, nil
+}
+func (s *stubOracle) GetCachedCirculatedICY() (*model.Web3BigInt, error) { return nil, nil }
+func (s *stubOracle) GetCachedBTCSupply() (*model.Web3BigInt, error)     { return nil, nil }
+func (s *stubOracle) GetCirculatedICYWithContext(ctx context.Context) (*model.Web3BigInt, error) {
+	return nil, nil
+}
+func (s *stubOracle) GetBTCSupplyWithContext(ctx context.Context) (*model.Web3BigInt, error) {
+	return nil, nil
+}
+func (s *stubOracle) RefreshCirculatedICYAsync() error            { return nil }
+func (s *stubOracle) RefreshBTCSupplyAsync() error                { return nil }
+func (s *stubOracle) ClearAllCaches() error                       { return nil }
+func (s *stubOracle) GetCacheStatistics() *oracle.CacheStatistics { return nil }
+
+// --- CRIT-2 regression specs ------------------------------------------------
+
+var _ = Describe("ProcessSwapRequests status tracking (CRIT-2 regression)", func() {
+	var (
+		testLogger *logger.Logger
+		appConfig  *config.AppConfig
+		oracleSvc  *stubOracle
+	)
+
+	BeforeEach(func() {
+		testLogger = logger.New(environments.Test)
+		appConfig = &config.AppConfig{}
+		oracleSvc = &stubOracle{price: &model.Web3BigInt{Value: "1000000000000000", Decimal: 18}}
+	})
+
+	newService := func(swapReqStore *fakeSwapRequestStore, baseRPC *stubBaseRPC) *telemetry.Telemetry {
+		st := &store.Store{
+			OnchainIcyTransaction: &stubOnchainIcyTxStore{},
+			SwapRequest:           swapReqStore,
+		}
+		return telemetry.New(nil, st, appConfig, testLogger, nil, baseRPC, oracleSvc)
+	}
+
+	It("settles a pending swap request at most once across repeated cron ticks", func() {
+		req := &model.SwapRequest{
+			ICYAmount:  "5000000000000000000000",
+			BTCAddress: "tb1qtest123",
+			IcyTx:      "0xswap-once",
+			Status:     model.SwapRequestStatusPending,
+		}
+		swapReqStore := newFakeSwapRequestStore(req)
+		baseRPC := &stubBaseRPC{}
+		svc := newService(swapReqStore, baseRPC)
+
+		// Tick 1: the request is pending, so it gets swapped and settled.
+		Expect(svc.ProcessSwapRequests()).To(Succeed())
+		Expect(baseRPC.callCount()).To(Equal(1))
+		Expect(swapReqStore.statusOf(req.IcyTx)).To(Equal(model.SwapRequestStatusCompleted))
+
+		// Tick 2: this is the ~2-minute cron re-run that caused CRIT-2. The
+		// request is no longer 'pending', so FindPendingSwapRequests must not
+		// return it, and baseRPC.Swap must not be called again.
+		Expect(svc.ProcessSwapRequests()).To(Succeed())
+		Expect(baseRPC.callCount()).To(Equal(1), "a completed swap request must not be re-swapped on a later tick")
+	})
+
+	It("never re-processes a request that is already 'processing' or 'completed'", func() {
+		processing := &model.SwapRequest{ICYAmount: "1", BTCAddress: "a", IcyTx: "0xprocessing", Status: model.SwapRequestStatusProcessing}
+		completed := &model.SwapRequest{ICYAmount: "1", BTCAddress: "b", IcyTx: "0xcompleted", Status: model.SwapRequestStatusCompleted}
+		failed := &model.SwapRequest{ICYAmount: "1", BTCAddress: "c", IcyTx: "0xfailed", Status: model.SwapRequestStatusFailed}
+		swapReqStore := newFakeSwapRequestStore(processing, completed, failed)
+		baseRPC := &stubBaseRPC{}
+		svc := newService(swapReqStore, baseRPC)
+
+		Expect(svc.ProcessSwapRequests()).To(Succeed())
+		Expect(baseRPC.callCount()).To(Equal(0), "only 'pending' requests may ever reach baseRPC.Swap")
+	})
+
+	It("marks a failed swap 'failed' (terminal), not left re-triable as 'pending'", func() {
+		req := &model.SwapRequest{
+			ICYAmount:  "5000000000000000000000",
+			BTCAddress: "tb1qtest123",
+			IcyTx:      "0xswap-fails",
+			Status:     model.SwapRequestStatusPending,
+		}
+		swapReqStore := newFakeSwapRequestStore(req)
+		baseRPC := &stubBaseRPC{swapErr: errors.New("rpc: swap reverted")}
+		svc := newService(swapReqStore, baseRPC)
+
+		Expect(svc.ProcessSwapRequests()).To(Succeed())
+		Expect(baseRPC.callCount()).To(Equal(1))
+		Expect(swapReqStore.statusOf(req.IcyTx)).To(Equal(model.SwapRequestStatusFailed))
+
+		// A second tick must still not re-swap a failed (non-pending) request.
+		Expect(svc.ProcessSwapRequests()).To(Succeed())
+		Expect(baseRPC.callCount()).To(Equal(1))
+	})
+
+	It("reuses the same nonce for the same request across attempts", func() {
+		req := &model.SwapRequest{
+			ICYAmount:  "5000000000000000000000",
+			BTCAddress: "tb1qtest123",
+			IcyTx:      "0xsame-request",
+			Status:     model.SwapRequestStatusPending,
+		}
+		swapReqStore := newFakeSwapRequestStore(req)
+		baseRPC := &stubBaseRPC{swapErr: errors.New("transient network blip")}
+		svc := newService(swapReqStore, baseRPC)
+
+		// First attempt fails -> status becomes 'failed'.
+		Expect(svc.ProcessSwapRequests()).To(Succeed())
+		Expect(baseRPC.callCount()).To(Equal(1))
+		Expect(swapReqStore.statusOf(req.IcyTx)).To(Equal(model.SwapRequestStatusFailed))
+
+		// An operator manually re-queues the request for a legitimate retry.
+		swapReqStore.mu.Lock()
+		swapReqStore.requests[req.IcyTx].Status = model.SwapRequestStatusPending
+		swapReqStore.mu.Unlock()
+		baseRPC.swapErr = nil
+
+		Expect(svc.ProcessSwapRequests()).To(Succeed())
+		Expect(baseRPC.callCount()).To(Equal(2))
+		Expect(baseRPC.nonces[0].Cmp(baseRPC.nonces[1])).To(Equal(0),
+			"retrying the same request must reuse its nonce so the on-chain replay guard can dedupe it")
+	})
+})


### PR DESCRIPTION
Sub-goal 04 of icy-swap-hardening (DF-75). Closes **CRIT-2**: `ProcessSwapRequests` never advanced swap-request status, so every ~2-minute cron tick re-swapped the same pending row with a fresh `time.Now().UnixNano()` nonce — the contract's `swappedHashes` replay guard could never dedupe → a new BTC payout every tick, forever.

**Fix:** the row is claimed (`pending → processing` via `UpdateStatus`) immediately before the on-chain `Swap`, then settled `completed`/`failed`. The nonce is now deterministic (`keccak256(icyTx)`) so a genuine retry dedupes on-chain. Transient pre-swap validation failures still leave the row `pending` (retry preserved).

Deliberate deviation from "same DB transaction": the on-chain RPC is not wrapped in a SQL tx (holding a DB tx across a network call is an anti-pattern); the claim commits atomically just before the swap. Still guarantees at-most-once settlement.

**Verification:** 4 specs pass + fail-on-old (3/4 fail when the claim logic is stripped). Proof-of-done: `docs/verification/flowb-status.md`. Note: a pre-existing broken sibling test file (`btc_multi_endpoint_test.go`, identical on develop) is excluded, not touched.

**Alternative for Han:** if icy.so uses only Flow A (`generate-signature`), retiring Flow B entirely is cleaner but removes a live route — needs frontend confirmation. **Also see DF-85** (100× settlement overpay) which lives in this same path.

Gate PR — held for Han's review; do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
