### PR TITLE
fix(cors): never pair wildcard origin with credentials

### DIFF
--- a/internal/transport/http/http.go
+++ b/internal/transport/http/http.go
@@ -23,19 +23,32 @@ import (
 
 func setupCORS(r *gin.Engine, cfg *config.AppConfig) {
 	corsOrigins := strings.Split(cfg.ApiServer.AllowedOrigins, ";")
-	r.Use(func(c *gin.Context) {
-		cors.New(
-			cors.Config{
-				AllowOrigins: corsOrigins,
-				AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"},
-				AllowHeaders: []string{
-					"Origin", "Host", "Content-Type", "Content-Length", "Accept-Encoding", "Accept-Language", "Accept",
-					"X-CSRF-Token", "Authorization", "X-Requested-With", "X-Access-Token",
-				},
-				AllowCredentials: true,
-			},
-		)(c)
-	})
+
+	// A wildcard origin and credentialed CORS are mutually exclusive under the
+	// Fetch spec: a browser will not expose a credentialed response to "*", and
+	// emitting both Access-Control-Allow-Origin:* and Allow-Credentials:true is a
+	// misconfiguration. If any configured origin is "*", drop credentials so the
+	// two can never be sent together. Prod should still narrow AllowedOrigins to
+	// the real front-ends (icy.so, icy.d.foundation) rather than rely on "*".
+	allowCredentials := true
+	for _, o := range corsOrigins {
+		if strings.TrimSpace(o) == "*" {
+			allowCredentials = false
+			break
+		}
+	}
+
+	// Build the middleware once and register it, instead of allocating a new
+	// cors handler on every request.
+	r.Use(cors.New(cors.Config{
+		AllowOrigins: corsOrigins,
+		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"},
+		AllowHeaders: []string{
+			"Origin", "Host", "Content-Type", "Content-Length", "Accept-Encoding", "Accept-Language", "Accept",
+			"X-CSRF-Token", "Authorization", "X-Requested-With", "X-Access-Token",
+		},
+		AllowCredentials: allowCredentials,
+	}))
 }
 
 // recognizedNonProdEnvs is the allowlist of APP_ENV values that may bypass the


### PR DESCRIPTION
## What

`api.icy.so` returns `Access-Control-Allow-Origin: *` together with `Access-Control-Allow-Credentials: true`.

## Why it matters

Per the Fetch spec these two are mutually exclusive: a browser will not expose a credentialed response to a wildcard origin. Emitting both is a misconfiguration that presents a broader CORS surface than intended and signals sloppiness on a treasury-adjacent API.

## Change

- In `setupCORS`, drop `AllowCredentials` to `false` whenever any configured origin is `"*"`, so the wildcard and credentials can never be sent together.
- Build the cors middleware **once** and register it, instead of allocating a new `cors.New(...)` handler on every request (the old code wrapped it in a per-request closure).

No behavior change for correctly-configured explicit origins (credentials stay on).

## Follow-up (deploy-side, not in this PR)

Production `API_ALLOWED_ORIGINS` should be narrowed from `*` to the real front-ends (`https://icy.so;https://icy.d.foundation`). This code change makes `*` safe; the env change removes it entirely.

## Test

- `go build ./internal/transport/http/` and `go vet ./...` on the package pass (go 1.24.2, the module-pinned toolchain).
