### PR TITLE
fix(health): report unhealthy when the service cannot quote a rate

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -42,7 +42,7 @@ func New(appConfig *config.AppConfig, logger *logger.Logger,
 		OracleHandler:      oracle.New(oracleSvc, logger, appConfig, metricsRecorder),
 		SwapHandler:        swap.New(logger, appConfig, oracleSvc, baseRPC, btcRPC, metricsRecorder),
 		TransactionHandler: transaction.NewTransactionHandler(db, onchainbtcprocessedtransaction.New()),
-		HealthHandler:      health.New(appConfig, logger, db, btcRPC, baseRPC, nil),
+		HealthHandler:      health.New(appConfig, logger, db, btcRPC, baseRPC, oracleSvc, nil),
 		MetricsHandler:     metrics.NewMetricsHandler(metricsRegistry),
 	}
 }
@@ -63,7 +63,7 @@ func NewWithMonitoring(appConfig *config.AppConfig, logger *logger.Logger,
 		OracleHandler:      oracle.New(oracleSvc, logger, appConfig, metricsRecorder),
 		SwapHandler:        swap.New(logger, appConfig, oracleSvc, baseRPC, btcRPC, metricsRecorder),
 		TransactionHandler: transaction.NewTransactionHandler(db, onchainbtcprocessedtransaction.New()),
-		HealthHandler:      health.New(appConfig, logger, db, btcRPC, baseRPC, jobStatusManager),
+		HealthHandler:      health.New(appConfig, logger, db, btcRPC, baseRPC, oracleSvc, jobStatusManager),
 		MetricsHandler:     metrics.NewMetricsHandler(metricsRegistry),
 	}
 }

--- a/internal/handler/health/health.go
+++ b/internal/handler/health/health.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dwarvesf/icy-backend/internal/baserpc"
 	"github.com/dwarvesf/icy-backend/internal/btcrpc"
 	"github.com/dwarvesf/icy-backend/internal/monitoring"
+	"github.com/dwarvesf/icy-backend/internal/oracle"
 	"github.com/dwarvesf/icy-backend/internal/utils/config"
 	"github.com/dwarvesf/icy-backend/internal/utils/logger"
 )
@@ -24,17 +25,19 @@ type HealthHandler struct {
 	db               *gorm.DB
 	btcRPC           btcrpc.IBtcRpc
 	baseRPC          baserpc.IBaseRPC
+	oracle           oracle.IOracle
 	jobStatusManager *monitoring.JobStatusManager
 }
 
 // New creates a new health handler instance
-func New(config *config.AppConfig, logger *logger.Logger, db *gorm.DB, btcRPC btcrpc.IBtcRpc, baseRPC baserpc.IBaseRPC, jobStatusManager *monitoring.JobStatusManager) IHealthHandler {
+func New(config *config.AppConfig, logger *logger.Logger, db *gorm.DB, btcRPC btcrpc.IBtcRpc, baseRPC baserpc.IBaseRPC, oracleSvc oracle.IOracle, jobStatusManager *monitoring.JobStatusManager) IHealthHandler {
 	return &HealthHandler{
 		config:           config,
 		logger:           logger,
 		db:               db,
 		btcRPC:           btcRPC,
 		baseRPC:          baseRPC,
+		oracle:           oracleSvc,
 		jobStatusManager: jobStatusManager,
 	}
 }
@@ -138,6 +141,16 @@ func (h *HealthHandler) External(c *gin.Context) {
 		baseCheck := h.checkBaseAPI(ctx)
 		mu.Lock()
 		response.Checks["base_rpc"] = baseCheck
+		mu.Unlock()
+	}()
+
+	// Check the capability that actually matters: can we quote a rate?
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rateCheck := h.checkSwapRate()
+		mu.Lock()
+		response.Checks["swap_rate"] = rateCheck
 		mu.Unlock()
 	}()
 
@@ -313,6 +326,47 @@ func (h *HealthHandler) checkBaseAPI(ctx context.Context) HealthCheck {
 		}
 	}
 
+	check.Latency = time.Since(start).Milliseconds()
+	return check
+}
+// checkSwapRate reports whether the service can actually quote a swap rate.
+//
+// The existing base_rpc check calls ICYTotalSupply once and is explicitly a
+// "lightweight check". GetCirculatedICY needs ELEVEN calls (one per locked
+// treasury plus total supply), so under RPC rate limiting the light probe
+// succeeds while the real work fails. That is exactly what production did on
+// 2026-07-20: /health/external reported healthy for the whole time
+// /swap/info was returning partial_data with no rate and swapping was paused.
+//
+// A health check that passes while the product is down is worse than no check,
+// because it actively suppresses the alarm.
+//
+// This uses the CACHED accessor deliberately: on a warm cache it costs
+// nothing, and when the circuit breaker is open it fails immediately without
+// issuing any RPC call, so making the check honest adds no load to the
+// dependency that is already struggling.
+func (h *HealthHandler) checkSwapRate() HealthCheck {
+	start := time.Now()
+	check := HealthCheck{Metadata: make(map[string]interface{})}
+
+	if h.oracle == nil {
+		// Not wired (some constructions pass nil). Report unknown rather than
+		// claiming health we cannot observe.
+		check.Status = "unknown"
+		check.Error = "oracle not available to health handler"
+		check.Latency = time.Since(start).Milliseconds()
+		return check
+	}
+
+	if _, err := h.oracle.GetCachedCirculatedICY(); err != nil {
+		check.Status = "unhealthy"
+		check.Error = err.Error()
+		check.Metadata["impact"] = "cannot quote a swap rate, swapping is paused"
+		check.Latency = time.Since(start).Milliseconds()
+		return check
+	}
+
+	check.Status = "healthy"
 	check.Latency = time.Since(start).Milliseconds()
 	return check
 }

--- a/internal/handler/health/swaprate_test.go
+++ b/internal/handler/health/swaprate_test.go
@@ -1,0 +1,65 @@
+package health
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dwarvesf/icy-backend/internal/model"
+	"github.com/dwarvesf/icy-backend/internal/oracle"
+)
+
+// stubOracle implements just enough of oracle.IOracle to drive checkSwapRate.
+type stubOracle struct {
+	oracle.IOracle // embedded: only the method under test is overridden
+	err            error
+}
+
+func (s *stubOracle) GetCachedCirculatedICY() (*model.Web3BigInt, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &model.Web3BigInt{Value: "14394960000000000000000", Decimal: 18}, nil
+}
+
+// The regression this exists for: on 2026-07-20 /health/external reported
+// healthy for over twenty minutes while /swap/info returned partial_data with
+// no rate and swapping was paused. base_rpc passed because it makes ONE call;
+// GetCirculatedICY needs eleven and was failing.
+func TestCheckSwapRate_UnhealthyWhenRateUnavailable(t *testing.T) {
+	h := &HealthHandler{
+		oracle: &stubOracle{err: errors.New("circuit breaker is open")},
+	}
+
+	got := h.checkSwapRate()
+
+	if got.Status != "unhealthy" {
+		t.Fatalf("status = %q, want unhealthy: a health check that passes while swapping is paused suppresses the alarm", got.Status)
+	}
+	if got.Error == "" {
+		t.Fatal("expected the underlying error to be surfaced")
+	}
+	if got.Metadata["impact"] == nil {
+		t.Fatal("expected the user-facing impact to be stated")
+	}
+}
+
+func TestCheckSwapRate_HealthyWhenRateAvailable(t *testing.T) {
+	h := &HealthHandler{oracle: &stubOracle{}}
+
+	if got := h.checkSwapRate(); got.Status != "healthy" {
+		t.Fatalf("status = %q, want healthy", got.Status)
+	}
+}
+
+// Never claim health we cannot observe.
+func TestCheckSwapRate_UnknownWhenOracleMissing(t *testing.T) {
+	h := &HealthHandler{}
+
+	got := h.checkSwapRate()
+	if got.Status == "healthy" {
+		t.Fatal("a nil oracle must not report healthy")
+	}
+	if got.Status != "unknown" {
+		t.Fatalf("status = %q, want unknown", got.Status)
+	}
+}


### PR DESCRIPTION
fix(health): report unhealthy when the service cannot quote a rate

On 2026-07-20 /health/external reported healthy for over twenty minutes
while /swap/info returned partial_data with no icy_satoshi_rate and
swapping was paused. Nothing alerted. The outage was found by looking at
the website.

The existing base_rpc check calls ICYTotalSupply once and its own comment
calls it "a lightweight check". GetCirculatedICY needs ELEVEN calls, one
per locked treasury plus total supply, so under RPC rate limiting the
light probe passes while the real work fails. The check was measuring
reachability; the thing that breaks is throughput.

Measured while diagnosing: the full eleven-call sequence completes in
1.79s against a paid endpoint with zero failures and returns the correct
circulating supply, while a rapid sequence against the public endpoint
returned HTTP 403 on the second call. So the operation is sound and the
dependency is rate limiting, which is precisely the condition a
one-call probe cannot see.

Adds a swap_rate check that reports on the capability users actually
depend on. It uses the CACHED accessor deliberately: warm cache costs
nothing, and when the circuit breaker is open it fails immediately
without issuing any RPC call, so making the check honest adds no load to
the dependency that is already struggling.

A nil oracle reports "unknown", never "healthy". Never claim health that
cannot be observed.

A health check that passes while the product is down is worse than no
check, because it actively suppresses the alarm. Same shape as the
orphaned heartbeat found earlier today: a green signal that is not true.

Full suite: 16 packages pass, 0 fail.
