### PR TITLE
fix(settlement): run the confirm sweep on every tick, not only busy ones

### DIFF
--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -241,6 +241,27 @@ func (t *Telemetry) withSettlementLock(fn func() error) error {
 func (t *Telemetry) processPendingBtcTransactions() error {
 	t.logger.Info("[ProcessPendingBtcTransactions] Start processing pending BTC transactions...")
 
+	// Confirm-before-complete sweep: promote any broadcasted rows that have
+	// reached MinBtcConfirmations to completed (firing the completed webhook),
+	// and route stuck (never-confirming) sends to needs_reconcile.
+	//
+	// DEFERRED, not tail-called. This used to sit at the end of the function,
+	// below the "no pending transactions" early return, so it only ran on ticks
+	// that happened to find new work. A payout broadcast into a quiet period
+	// therefore stayed "broadcasted" forever: swap 2026-07-20 10:29 confirmed on
+	// chain at 10:33 and was still reported as sending 3.6 hours later, because
+	// no further swap came along to drag the sweep with it. The stuck-tx
+	// detector lives in the same sweep, so that was blind for the same reason.
+	// Deferring covers every return path, including ones added later. Errors are
+	// logged inside; a sweep failure must not fail the pending-processing pass.
+	defer func() {
+		if cerr := t.ConfirmBroadcastedBtcTransactions(); cerr != nil {
+			t.logger.Error("[ProcessPendingBtcTransactions][ConfirmBroadcasted]", map[string]string{
+				"error": cerr.Error(),
+			})
+		}
+	}()
+
 	// Fetch all pending BTC processed transactions
 	pendingTxs, err := t.store.OnchainBtcProcessedTransaction.GetPendingTransactions(t.db)
 	if err != nil {
@@ -475,17 +496,6 @@ func (t *Telemetry) processPendingBtcTransactions() error {
 		}
 
 		t.logger.Info(fmt.Sprintf("[ProcessPendingBtcTransactions] Transaction broadcast, awaiting confirmation: %s", tx))
-	}
-
-	// Confirm-before-complete sweep: promote any broadcasted rows that have
-	// reached MinBtcConfirmations to completed (firing the completed webhook), and
-	// route stuck (never-confirming) sends to needs_reconcile. Runs on the same
-	// settlement tick so no extra cron wiring is needed. Errors are logged inside;
-	// a sweep failure must not fail the pending-processing pass.
-	if cerr := t.ConfirmBroadcastedBtcTransactions(); cerr != nil {
-		t.logger.Error("[ProcessPendingBtcTransactions][ConfirmBroadcasted]", map[string]string{
-			"error": cerr.Error(),
-		})
 	}
 
 	return nil


### PR DESCRIPTION
The confirm-before-complete sweep only ran on ticks that happened to find new
work, so a payout broadcast into a quiet period stayed `broadcasted` forever.

## What was observed

A live swap, traced end to end:

```
10:29:21Z  swap created
10:30:05Z  backend records "broadcasted"            +44s
10:33:49Z  CONFIRMED on chain, block 958865         +4m,  1.0 sat/vB, 141 sat miner fee
14:06:00Z  still reported as sending                +3h36m
```

The Bitcoin side was never slow. The money landed in four minutes and the row
was simply never advanced. Users were told their payout was in flight while it
had already arrived.

## Why

`ConfirmBroadcastedBtcTransactions()` was tail-called at the bottom of
`processPendingBtcTransactions`, below this:

```go
if len(pendingTxs) == 0 {
    return nil          // ← sweep never reached
}
```

So a broadcast row was only promoted to `completed` when another swap happened
to be pending on a later tick. The existing comment ("Runs on the same
settlement tick so no extra cron wiring is needed") describes the intent
correctly; the early return defeated it.

**The more dangerous half:** the stuck-tx detector lives in the same sweep. A
payout that genuinely never confirmed would not have been routed to
`needs_reconcile` either, for as long as the queue stayed quiet. The safety net
was blind under exactly the conditions it exists for.

## The change

Deferred rather than moved up, so every return path is covered including ones
added later.

## Risk

The sweep moves no money. It reads confirmations, updates a status, and emits a
webhook, with the stuck path explicitly routing to `needs_reconcile` for manual
RBF rather than auto-resending. Running it on every tick is therefore safe, and
the blast radius on deploy is the single `broadcasted` row currently
outstanding, which will flip to `completed` and fire one webhook.

## Verification

`go build ./...` and `go vet ./internal/telemetry/` clean.

**No unit test.** `Telemetry` holds a concrete `*gorm.DB` and `*store.Store` and
the repo has no mock infrastructure, so covering this properly means building a
DB harness that does not exist yet. That is worth doing and is not in this
change. The deploy itself is the proof available today: the outstanding row
should reach `completed` within one 2-minute tick, and that will be checked
against the live API rather than assumed.
