### PR TITLE
test(settlement): cover the quiet tick that let the stale-status bug through

### DIFF
--- a/internal/server/settlement_quiet_tick_test.go
+++ b/internal/server/settlement_quiet_tick_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dwarvesf/icy-backend/internal/model"
+)
+
+// The confirm sweep has to run on EVERY settlement tick, not only on ticks that
+// happen to find pending work.
+//
+// This is the gap that let a production bug through on 2026-07-20. The sweep was
+// tail-called at the bottom of processPendingBtcTransactions, below its
+// "no pending transactions" early return, so a payout broadcast into a quiet
+// period was never promoted. A live swap confirmed on chain in 4 minutes and was
+// still reported as "sending" 3.6 hours later; the stuck-tx detector shares the
+// same sweep, so it was blind under exactly the conditions it exists for.
+//
+// The existing suite could not catch it: every confirmation test calls
+// ConfirmBroadcastedBtcTransactions() directly, which proves the sweep WORKS but
+// never that it gets CALLED. These tests go through the public entry point the
+// cron actually drives, with the pending queue deliberately empty.
+
+// A broadcasted payout that has confirmed must reach completed on a tick where
+// there is nothing pending, because that is the normal state between swaps.
+func TestProcessPending_QuietQueue_StillCompletesConfirmedPayout(t *testing.T) {
+	db := newTestDB(t)
+	btc := &mockBtcRpc{} // unset confirmations means deeply confirmed
+	tel := newTelemetry(t, db, btc)
+
+	id := seedBroadcasted(t, db, "72621", "3000", "btc-tx-hash", time.Now().Add(-4*time.Minute))
+
+	// No pending rows seeded on purpose: this is the early-return path.
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("settlement tick: %v", err)
+	}
+
+	if got := statusOf(t, db, id); got != model.BtcProcessingStatusCompleted {
+		t.Fatalf("status = %q, want completed. The confirm sweep did not run on a "+
+			"tick with no pending work, so a confirmed payout stays 'broadcasted' "+
+			"until another swap happens to drag the sweep along.", got)
+	}
+	if btc.count() != 0 {
+		t.Fatalf("send count = %d, want 0: a quiet tick must not broadcast anything", btc.count())
+	}
+}
+
+// The other half of the same wiring: a broadcast that never confirms has to be
+// routed to needs_reconcile on a quiet tick too. This is the safety net, and it
+// was equally unreachable.
+func TestProcessPending_QuietQueue_StillFlagsStuckPayout(t *testing.T) {
+	db := newTestDB(t)
+	btc := &mockBtcRpc{confirmations: 0, confHardcoded: true} // never confirms
+	tel := newTelemetry(t, db, btc)
+
+	// Broadcast long enough ago to be past any stuck timeout.
+	id := seedBroadcasted(t, db, "72621", "3000", "btc-tx-hash", time.Now().Add(-72*time.Hour))
+
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("settlement tick: %v", err)
+	}
+
+	if got := statusOf(t, db, id); got == model.BtcProcessingStatusBroadcasted {
+		t.Fatalf("status = %q: an unconfirmed payout was never assessed on a quiet "+
+			"tick, so the stuck-tx detector cannot fire without unrelated traffic", got)
+	}
+	if btc.count() != 0 {
+		t.Fatalf("send count = %d, want 0: a stuck payout is flagged for manual RBF, never auto-resent", btc.count())
+	}
+}


### PR DESCRIPTION
Two tests through `ProcessPendingBtcTransactions` with the pending queue deliberately empty: a confirmed payout must reach `completed`, and an unconfirmed one must be assessed for the stuck path.

**Negative control run, not assumed.** Both fail on the pre-fix code with the exact production symptom:

```
--- FAIL: TestProcessPending_QuietQueue_StillCompletesConfirmedPayout
    status = "broadcasted", want completed. The confirm sweep did not run on a
    tick with no pending work...
--- FAIL: TestProcessPending_QuietQueue_StillFlagsStuckPayout
    status = "broadcasted": an unconfirmed payout was never assessed on a quiet
    tick, so the stuck-tx detector cannot fire without unrelated traffic
```

Both pass on the fix, and the full `internal/server` suite is green.

## Why 1,659 lines of settlement tests missed this

Every confirmation test calls `ConfirmBroadcastedBtcTransactions()` **directly**. They prove the sweep WORKS, never that it gets CALLED. The bug lived in the wiring one level above where the suite was looking. Compounding it, every `TestProcessPending_*` case seeds pending work, so the early-return path had no coverage at all.

## Correction

On PR #46 I wrote that this repo has no mock infrastructure and that testing this meant building a DB harness from scratch. **That was wrong.** The harness exists and is good: in-memory sqlite, a configurable `mockBtcRpc`, `seed`/`statusOf` helpers. I should have read the suite before saying it.