### PR TITLE
fix(settlement): stop unpayable payouts looping and cap refusals ratcheting

### DIFF
--- a/internal/handler/swap/swap.go
+++ b/internal/handler/swap/swap.go
@@ -239,8 +239,15 @@ func (h *handler) GenerateSignature(c *gin.Context) {
 	if svcFeeDecimal.LessThan(minFeeDecimal) {
 		svcFeeDecimal = minFeeDecimal
 	}
-	if btcDecimal.Sub(svcFeeDecimal).IsNegative() {
-		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, errors.New("Sat amount is not enough to pay service fee"), nil, "failed to generate signature"))
+	// Gate on the NET amount, which is what actually gets sent, not on the
+	// subtotal being merely non-negative. The dust check above runs on the
+	// subtotal, so with the 3,000 sat minimum fee a subtotal of 3,000..3,545
+	// cleared both gates and produced a payout of 0..545 sat: at or under every
+	// dust limit, unbroadcastable forever. The user's ICY burns and no BTC can
+	// ever be sent, so it has to be refused here, before anything is signed.
+	netDecimal := btcDecimal.Sub(svcFeeDecimal)
+	if netDecimal.IsNegative() || h.btcRPC.IsDust(req.BTCAddress, netDecimal.IntPart()) {
+		c.JSON(http.StatusBadRequest, view.CreateResponse[any](nil, errors.New("amount after service fee is dust"), nil, "the amount left after the service fee is too small to send on Bitcoin"))
 		return
 	}
 

--- a/internal/model/onchain_btc_processed_transaction.go
+++ b/internal/model/onchain_btc_processed_transaction.go
@@ -29,6 +29,16 @@ const (
 	// picks it up. Contrast with "failed" (definitely-not-sent, safe) and
 	// "processing" (claimed / crash-stranded).
 	BtcProcessingStatusNeedsReconcile BtcProcessingStatus = "needs_reconcile"
+	// BtcProcessingStatusRefused is a TERMINAL state for a payout this service
+	// DEFINITIVELY never broadcast, because a policy control refused it (the
+	// daily cap, or a cap that could not be evaluated). Distinct from
+	// needs_reconcile, which means "a POST was attempted, BTC may be live".
+	// Conflating the two made refusals count as outflow: a refusal added its own
+	// amount to the rolling 24h total, which pushed the next payout over the cap,
+	// which refused and added again. The cap ratcheted itself shut for 24 hours
+	// without a satoshi leaving the treasury. Refused rows are excluded from the
+	// sent-states sum for exactly that reason.
+	BtcProcessingStatusRefused BtcProcessingStatus = "refused"
 )
 
 type OnchainBtcProcessedTransaction struct {

--- a/internal/server/caps_test.go
+++ b/internal/server/caps_test.go
@@ -94,8 +94,12 @@ func TestProcessPending_DailyCapCrossed_RefusesCrosser(t *testing.T) {
 	if btc.count() != 0 {
 		t.Fatalf("daily-cap crosser was sent: send count = %d, want 0", btc.count())
 	}
-	if got := statusOf(t, db, crosser); got != model.BtcProcessingStatusNeedsReconcile {
-		t.Fatalf("crosser status = %q, want needs_reconcile", got)
+	// "refused", not "needs_reconcile". A cap crosser was definitively never
+	// broadcast, and needs_reconcile counts toward the rolling total, so the old
+	// expectation encoded the ratchet: each refusal inflated the sum that caused
+	// it. needs_reconcile now means only "a POST was attempted, BTC may be live".
+	if got := statusOf(t, db, crosser); got != model.BtcProcessingStatusRefused {
+		t.Fatalf("crosser status = %q, want refused", got)
 	}
 	if got := statusOf(t, db, alreadySent); got != model.BtcProcessingStatusCompleted {
 		t.Fatalf("already-sent row disturbed: status = %q, want completed", got)
@@ -104,7 +108,7 @@ func TestProcessPending_DailyCapCrossed_RefusesCrosser(t *testing.T) {
 
 // DAILY CAP (sequence). Three identical 900-sat payouts under a 2000-sat daily
 // cap in ONE settlement pass: the first two send (900, then 1800, both <= 2000),
-// the third would reach 2700 > 2000 and is refused to needs_reconcile. Proves the
+// the third would reach 2700 > 2000 and is refused. Proves the
 // rolling sum re-evaluates within the loop (each broadcast counts toward the next
 // row's check) so exactly the crossing payout is stopped.
 func TestProcessPending_SequenceCrossesDailyCap_RefusesOnlyCrosser(t *testing.T) {
@@ -125,8 +129,8 @@ func TestProcessPending_SequenceCrossesDailyCap_RefusesOnlyCrosser(t *testing.T)
 	if got := countStatus(t, db, model.BtcProcessingStatusCompleted); got != 2 {
 		t.Fatalf("completed rows = %d, want 2", got)
 	}
-	if got := countStatus(t, db, model.BtcProcessingStatusNeedsReconcile); got != 1 {
-		t.Fatalf("needs_reconcile rows = %d, want 1 (the crosser)", got)
+	if got := countStatus(t, db, model.BtcProcessingStatusRefused); got != 1 {
+		t.Fatalf("refused rows = %d, want 1 (the crosser)", got)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"context"
 	"net/http"
 	"os"
@@ -115,6 +116,20 @@ func Init() {
 		logger,
 		appConfig,
 	)
+
+	// The effective drain-prevention limits, logged once at boot. These are the
+	// only controls bounding how much BTC can leave, and they were previously
+	// unreadable from outside the process: an operator could not tell a
+	// configured value from a placeholder default without a redeploy. 0 means
+	// the cap is DISABLED, which is worth seeing in a log line.
+	logger.Info("[Init] effective payout limits", map[string]string{
+		"max_payout_satoshi":       fmt.Sprintf("%d", appConfig.Bitcoin.MaxPayoutSatoshi),
+		"max_daily_payout_satoshi": fmt.Sprintf("%d", appConfig.Bitcoin.MaxDailyPayoutSatoshi),
+		"min_btc_confirmations":    fmt.Sprintf("%d", appConfig.Bitcoin.MinBtcConfirmations),
+		"min_swap_confirmations":   fmt.Sprintf("%d", appConfig.Blockchain.MinSwapConfirmations),
+		"service_fee_rate":         fmt.Sprintf("%v", appConfig.Bitcoin.ServiceFeeRate),
+		"min_satoshi_fee":          fmt.Sprintf("%d", appConfig.Bitcoin.MinSatshiFee),
+	})
 
 	c := cron.New()
 

--- a/internal/server/settlement_test.go
+++ b/internal/server/settlement_test.go
@@ -74,7 +74,11 @@ func (m *mockBtcRpc) GetTransactionsByAddress(address, fromTxId string) ([]model
 }
 func (m *mockBtcRpc) EstimateFees() (map[string]float64, error) { return map[string]float64{}, nil }
 func (m *mockBtcRpc) GetSatoshiUSDPrice() (float64, error)      { return 0, nil }
-func (m *mockBtcRpc) IsDust(address string, amount int64) bool  { return false }
+// Dust is a real rule, not a stub. Returning false unconditionally meant the
+// double accepted payouts the network rejects, so the guard that keeps an
+// unpayable row from looping forever could not be tested at all. 546 is the
+// standard P2PKH dust limit and a fair approximation of the per-type limits.
+func (m *mockBtcRpc) IsDust(address string, amount int64) bool { return amount < 546 }
 
 // ---- fixtures -----------------------------------------------------------
 

--- a/internal/server/unpayable_and_refusal_test.go
+++ b/internal/server/unpayable_and_refusal_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/dwarvesf/icy-backend/internal/model"
+	"github.com/dwarvesf/icy-backend/internal/utils/config"
+)
+
+// A payout whose net amount is dust can never be broadcast: UTXO selection
+// fails with fee > amount, which is an ErrNotBroadcast, which RELEASES the row
+// back to pending. Nothing bounded that, so the row re-failed on every tick
+// forever while the user's ICY stayed burned. It has to end terminally instead.
+func TestProcessPending_DustAmount_TerminalNotReleased(t *testing.T) {
+	db := newTestDB(t)
+	btc := &mockBtcRpc{}
+	tel := newTelemetry(t, db, btc)
+
+	// subtotal 3200, fee 3000 -> net 200 sat, under every dust limit.
+	id := seed(t, db, model.BtcProcessingStatusPending, "3200", "3000")
+
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("settlement tick: %v", err)
+	}
+
+	got := statusOf(t, db, id)
+	if got == model.BtcProcessingStatusPending {
+		t.Fatalf("status = %q: an unpayable row was released back to pending, so it "+
+			"will re-fail on every tick forever", got)
+	}
+	if got != model.BtcProcessingStatusFailed {
+		t.Fatalf("status = %q, want failed (terminal)", got)
+	}
+	if btc.count() != 0 {
+		t.Fatalf("send count = %d, want 0: a dust payout must never reach Send", btc.count())
+	}
+}
+
+// Zero specifically: the old guard was `amtInt < 0`, so a net of exactly zero
+// sailed past it. subtotal == fee produces exactly that.
+func TestProcessPending_ZeroNetAmount_TerminalNotReleased(t *testing.T) {
+	db := newTestDB(t)
+	btc := &mockBtcRpc{}
+	tel := newTelemetry(t, db, btc)
+
+	id := seed(t, db, model.BtcProcessingStatusPending, "3000", "3000") // net 0
+
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("settlement tick: %v", err)
+	}
+
+	if got := statusOf(t, db, id); got != model.BtcProcessingStatusFailed {
+		t.Fatalf("status = %q, want failed: a zero payout passed the `< 0` guard "+
+			"and reached Send", got)
+	}
+	if btc.count() != 0 {
+		t.Fatalf("send count = %d, want 0", btc.count())
+	}
+}
+
+// A payout refused by the daily cap was definitively never broadcast, so it
+// must NOT count toward the rolling total. It used to be written as
+// needs_reconcile, which IS counted, so each refusal inflated the very sum that
+// caused it and the cap ratcheted itself shut for 24 hours with nothing sent.
+func TestProcessPending_CapRefusal_DoesNotCountAsOutflow(t *testing.T) {
+	db := newTestDB(t)
+	btc := &mockBtcRpc{}
+	cfg := &config.AppConfig{}
+	cfg.Bitcoin.MaxDailyPayoutSatoshi = 10_000
+	tel := telWithBtc(t, db, btc, cfg)
+
+	// Over the cap on its own: refused, nothing sent.
+	refused := seed(t, db, model.BtcProcessingStatusPending, "50000", "3000")
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("first tick: %v", err)
+	}
+	if got := statusOf(t, db, refused); got != model.BtcProcessingStatusRefused {
+		t.Fatalf("status = %q, want refused (a cap refusal is definitively not sent)", got)
+	}
+	if btc.count() != 0 {
+		t.Fatalf("send count = %d, want 0", btc.count())
+	}
+
+	// The refusal must not have consumed any of the daily budget. A payout that
+	// fits under the cap has to go through on the next tick.
+	ok := seed(t, db, model.BtcProcessingStatusPending, "8000", "3000") // net 5000 < 10000
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("second tick: %v", err)
+	}
+	if got := statusOf(t, db, ok); got == model.BtcProcessingStatusRefused {
+		t.Fatalf("a payout under the cap was refused: the earlier refusal was counted "+
+			"as outflow, so the cap is ratcheting itself shut (status = %q)", got)
+	}
+	if btc.count() != 1 {
+		t.Fatalf("send count = %d, want 1: the under-cap payout should have been sent", btc.count())
+	}
+}

--- a/internal/store/onchainbtcprocessedtransaction/onchain_btc_processed_transaction.go
+++ b/internal/store/onchainbtcprocessedtransaction/onchain_btc_processed_transaction.go
@@ -123,6 +123,12 @@ func (s *store) GetPendingTransactions(tx *gorm.DB) ([]model.OnchainBtcProcessed
 //     stuck broadcast. Counted so the daily total is a true CEILING on outflow;
 //     over-counting a maybe-sent row is the safe direction for a drain-prevention
 //     control. "pending" / "processing" / "failed" are excluded (not sent).
+//
+// "refused" is DELIBERATELY excluded. It marks a payout a policy control
+// definitively never broadcast. It used to share needs_reconcile, so a
+// cap refusal counted its own amount as outflow, pushing the next payout over
+// the cap, which refused and counted again: the ceiling ratcheted itself shut
+// for 24 hours with nothing actually sent. Never add it to this list.
 var sentStates = []string{
 	string(model.BtcProcessingStatusBroadcasted),
 	string(model.BtcProcessingStatusCompleted),

--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -331,10 +331,17 @@ func (t *Telemetry) processPendingBtcTransactions() error {
 		// never actually fired. Check the parsed value so a subtotal below the
 		// service fee is rejected. Terminal (mark failed): a negative amount can
 		// never become sendable, and the row is already claimed to processing.
+		// <= 0 and dust are terminal too, not just < 0. Zero used to pass this
+		// guard and reach Send, where UTXO selection fails with fee > amount,
+		// which is an ErrNotBroadcast and so RELEASES the row back to pending.
+		// Nothing bounds that: the row re-failed on every tick forever, burning
+		// a UTXO fetch and a fee estimate each time. An unpayable amount can
+		// never become payable, so it must end here. Also catches rows created
+		// before the handler-side gate existed.
 		amtInt, ok := amount.Int64()
-		if !ok || amtInt < 0 {
+		if !ok || amtInt <= 0 || t.btcRpc.IsDust(pendingTx.BTCAddress, amtInt) {
 			t.logger.Error("[ProcessPendingBtcTransactions]", map[string]string{
-				"error":  "Amount is negative or unparseable",
+				"error":  "Amount is unpayable (non-positive, dust, or unparseable)",
 				"id":     fmt.Sprintf("%d", pendingTx.ID),
 				"amount": amount.Value,
 			})
@@ -383,34 +390,34 @@ func (t *Telemetry) processPendingBtcTransactions() error {
 				// FAIL CLOSED: if the rolling total cannot be computed, do NOT send.
 				// Route to needs_reconcile so the daily ceiling can never be breached
 				// on an unverified sum.
-				t.logger.Error("[ProcessPendingBtcTransactions][DailyCap] rolling-sum query failed, refusing (needs_reconcile, NOT sent)", map[string]string{
+				t.logger.Error("[ProcessPendingBtcTransactions][DailyCap] rolling-sum query failed, refusing (refused, NOT sent)", map[string]string{
 					"error": serr.Error(),
 					"id":    fmt.Sprintf("%d", pendingTx.ID),
 				})
-				if uerr := t.store.OnchainBtcProcessedTransaction.UpdateStatus(t.db, pendingTx.ID, model.BtcProcessingStatusNeedsReconcile); uerr != nil {
+				if uerr := t.store.OnchainBtcProcessedTransaction.UpdateStatus(t.db, pendingTx.ID, model.BtcProcessingStatusRefused); uerr != nil {
 					t.logger.Error("[ProcessPendingBtcTransactions][DailyCap][UpdateStatus]", map[string]string{
 						"error": uerr.Error(),
 						"id":    fmt.Sprintf("%d", pendingTx.ID),
 					})
 				}
-				t.emitSwapPayoutWebhook(webhookClient, pendingTx, model.BtcProcessingStatusNeedsReconcile, amount.Value, "")
+				t.emitSwapPayoutWebhook(webhookClient, pendingTx, model.BtcProcessingStatusRefused, amount.Value, "")
 				continue
 			}
 			if sent+amtInt > maxDaily {
-				t.logger.Error("[ProcessPendingBtcTransactions][DailyCap] rolling 24h cap would be crossed, refusing (needs_reconcile, NOT sent)", map[string]string{
+				t.logger.Error("[ProcessPendingBtcTransactions][DailyCap] rolling 24h cap would be crossed, refusing (refused, NOT sent)", map[string]string{
 					"id":          fmt.Sprintf("%d", pendingTx.ID),
 					"btc_address": pendingTx.BTCAddress,
 					"amount":      fmt.Sprintf("%d", amtInt),
 					"sent_24h":    fmt.Sprintf("%d", sent),
 					"cap":         fmt.Sprintf("%d", maxDaily),
 				})
-				if uerr := t.store.OnchainBtcProcessedTransaction.UpdateStatus(t.db, pendingTx.ID, model.BtcProcessingStatusNeedsReconcile); uerr != nil {
+				if uerr := t.store.OnchainBtcProcessedTransaction.UpdateStatus(t.db, pendingTx.ID, model.BtcProcessingStatusRefused); uerr != nil {
 					t.logger.Error("[ProcessPendingBtcTransactions][DailyCap][UpdateStatus]", map[string]string{
 						"error": uerr.Error(),
 						"id":    fmt.Sprintf("%d", pendingTx.ID),
 					})
 				}
-				t.emitSwapPayoutWebhook(webhookClient, pendingTx, model.BtcProcessingStatusNeedsReconcile, amount.Value, "")
+				t.emitSwapPayoutWebhook(webhookClient, pendingTx, model.BtcProcessingStatusRefused, amount.Value, "")
 				continue
 			}
 		}

--- a/internal/utils/config/config.go
+++ b/internal/utils/config/config.go
@@ -314,6 +314,27 @@ func New() *AppConfig {
 			config.Bitcoin.MinSatshiFee, _ = strconv.ParseInt(minSatoshiFee, 10, 64)
 		}
 
+		// The drain-prevention controls were missing from this block while every
+		// other Bitcoin setting was here. A treasurer who provisioned them where
+		// the rest live got the placeholder defaults instead, silently, and the
+		// two limits whose entire job is bounding a drain would have been sitting
+		// on sample values while everyone believed they were configured.
+		if v, _ := vc.GetKV("BTC_MAX_PAYOUT_SATOSHI"); v != "" {
+			config.Bitcoin.MaxPayoutSatoshi, _ = strconv.ParseInt(v, 10, 64)
+		}
+		if v, _ := vc.GetKV("BTC_MAX_DAILY_PAYOUT_SATOSHI"); v != "" {
+			config.Bitcoin.MaxDailyPayoutSatoshi, _ = strconv.ParseInt(v, 10, 64)
+		}
+		if v, _ := vc.GetKV("BTC_MIN_CONFIRMATIONS"); v != "" {
+			config.Bitcoin.MinBtcConfirmations, _ = strconv.ParseInt(v, 10, 64)
+		}
+		if v, _ := vc.GetKV("BTC_STUCK_TX_TIMEOUT_SECONDS"); v != "" {
+			config.Bitcoin.StuckTxTimeoutSeconds, _ = strconv.ParseInt(v, 10, 64)
+		}
+		if v, _ := vc.GetKV("BLOCKCHAIN_MIN_SWAP_CONFIRMATIONS"); v != "" {
+			config.Blockchain.MinSwapConfirmations, _ = strconv.ParseInt(v, 10, 64)
+		}
+
 		// Blockchain config
 		config.Blockchain.BaseRPCEndpoint, _ = vc.GetKV("BLOCKCHAIN_BASE_RPC_ENDPOINT")
 


### PR DESCRIPTION
Two High findings from the swap security review, plus the config gap that made the drain limits unverifiable.

**No migration.** `status` is `VARCHAR(20)` with no enum and no CHECK constraint, so the new terminal state is code-only. That was the thing worth checking before touching a production money DB.

## 1. Unpayable payouts looped forever (High)

The handler dust-checked the **subtotal**, then only required `subtotal - fee >= 0`. With the 3,000 sat minimum fee, a subtotal of 3,000..3,545 produces a net payout of 0..545 sat, at or under every dust limit. Settlement's guard was `amtInt < 0`, so **zero sailed past it**, reached `Send`, failed UTXO selection with `fee > amount` , and that is an `ErrNotBroadcast`, which **releases the row back to `pending`**.

Nothing bounded the retry. The row re-failed on every tick forever, burning a UTXO fetch and a fee estimate each time, while the user's ICY stayed burned with no BTC and no terminal state to alert on. Cheap to trigger repeatedly.

Gated on the **net** amount at the handler, and terminal at settlement so rows created before the handler gate are caught too.

## 2. Cap refusals counted as outflow (High)

`needs_reconcile` carried two incompatible meanings: *"a POST was attempted, BTC may be live"* and *"a policy control definitively refused this"*. `SumSentInWindow` counts it.

So a daily-cap refusal added its own amount to the rolling 24h total → pushed the next payout over the cap → refused → added again. **The ceiling ratcheted itself shut for 24 hours without a satoshi leaving the treasury**, and an attacker could trigger it cheaply once the cap was near.

Split out a `refused` terminal state, deliberately excluded from `sentStates` with a comment saying never to add it. `needs_reconcile` now means only "maybe on the wire".

## 3. The drain limits were invisible and half-configurable (Medium)

The Vault block re-read the fee settings but **not** `MAX_PAYOUT_SATOSHI`, `MAX_DAILY_PAYOUT_SATOSHI`, `MIN_CONFIRMATIONS`, `STUCK_TX_TIMEOUT_SECONDS` or `MIN_SWAP_CONFIRMATIONS`. A treasurer who provisioned them where every other Bitcoin setting lives silently got placeholder defaults, and the two controls whose entire job is bounding a drain could have been sitting on sample values.

All five now read from Vault, **and the effective values are logged once at boot** so a configured value can be told from a default without a redeploy. That log line is how to answer "are the caps real right now?" after this deploys.

## Tests

Three new cases, each **verified to FAIL on the pre-fix code** with the real symptom before being committed:

```
--- FAIL: TestProcessPending_DustAmount_TerminalNotReleased
--- FAIL: TestProcessPending_ZeroNetAmount_TerminalNotReleased
--- FAIL: TestProcessPending_CapRefusal_DoesNotCountAsOutflow
```

Two existing cap tests asserted the old `needs_reconcile` behaviour and were updated: their expectation **was** the conflation this fixes.

`mockBtcRpc.IsDust` returned `false` unconditionally, so the test double accepted payouts the network rejects and the dust guard could not be exercised at all. It now applies the 546 sat rule. Whole repo green, 16 packages.

## Still open, not in this PR

- **Attempt bound on release-to-pending.** This closes the dust loop specifically, but any other persistent `ErrNotBroadcast` (circuit breaker open, insufficient funds) still has no liveness bound. That needs an `attempts` column, i.e. a migration.
- **On-chain replay protection is unverified.** The backend signs `nonce = UnixNano` with no server-side nonce tracking, so replay protection rests entirely on the contract. The ABI exposes `swappedHashes(bytes32)`, which is the right pattern, but the Solidity source is not in this repo. Worth confirming.