### PR TITLE
fix(settlement): bound release-to-pending retries

### DIFF
--- a/internal/model/onchain_btc_processed_transaction.go
+++ b/internal/model/onchain_btc_processed_transaction.go
@@ -48,6 +48,11 @@ type OnchainBtcProcessedTransaction struct {
 	SwapTransactionHash       string                    `json:"swap_transaction_hash"`
 	BTCAddress                string                    `json:"btc_address"`
 	ProcessedAt               *time.Time                `json:"processed_at"`
+	// Attempts counts how many times this payout has been released back to
+	// pending after a definitely-not-broadcast failure. It is the liveness
+	// bound on that retry: without it a permanently-unsendable row re-failed on
+	// every settlement tick forever.
+	Attempts                  int                       `json:"attempts"`
 	Subtotal                  string                    `json:"subtotal"`
 	Total                     string                    `json:"total"`
 	Status                    BtcProcessingStatus       `json:"status"`

--- a/internal/server/retry_budget_test.go
+++ b/internal/server/retry_budget_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/dwarvesf/icy-backend/internal/btcrpc"
+	"github.com/dwarvesf/icy-backend/internal/model"
+	"github.com/dwarvesf/icy-backend/internal/utils/config"
+)
+
+// A pre-POST failure releases the row to pending so a healthy later tick can
+// retry. That is correct, but it had no bound: a permanently unsendable row
+// (empty treasury, every endpoint down) re-failed on every tick forever, with
+// the user's ICY already burned and no terminal state to alert on.
+func TestProcessPending_RetryBudget_EventuallyGivesUp(t *testing.T) {
+	db := newTestDB(t)
+	btc := &mockBtcRpc{
+		// Always fails BEFORE the POST, so releasing is safe and the old code
+		// would release forever.
+		sendFn: func(addr string, amt *model.Web3BigInt) (string, int64, error) {
+			return "", 0, btcrpc.ErrNotBroadcast
+		},
+	}
+	cfg := &config.AppConfig{}
+	cfg.Bitcoin.MaxBroadcastAttempts = 3
+	tel := telWithBtc(t, db, btc, cfg)
+
+	id := seed(t, db, model.BtcProcessingStatusPending, "50000", "3000")
+
+	// Ticks 1 and 2 release for retry; tick 3 spends the budget.
+	for i := 1; i <= 3; i++ {
+		if err := tel.ProcessPendingBtcTransactions(); err != nil {
+			t.Fatalf("tick %d: %v", i, err)
+		}
+		got := statusOf(t, db, id)
+		if i < 3 && got != model.BtcProcessingStatusPending {
+			t.Fatalf("tick %d: status = %q, want pending (budget not spent yet)", i, got)
+		}
+	}
+
+	if got := statusOf(t, db, id); got != model.BtcProcessingStatusFailed {
+		t.Fatalf("status = %q, want failed: the retry budget was spent and the row "+
+			"must stop being retried, not spin forever", got)
+	}
+
+	// A terminal row is never picked up again, however many ticks run.
+	before := btc.count()
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("post-terminal tick: %v", err)
+	}
+	if btc.count() != before {
+		t.Fatalf("a failed row was retried: send count %d -> %d", before, btc.count())
+	}
+}
+
+// The bound must not fire on a row that succeeds on a later attempt: a genuinely
+// transient failure has to keep its retries.
+func TestProcessPending_RetryBudget_TransientFailureStillRetries(t *testing.T) {
+	db := newTestDB(t)
+	calls := 0
+	btc := &mockBtcRpc{
+		sendFn: func(addr string, amt *model.Web3BigInt) (string, int64, error) {
+			calls++
+			if calls == 1 {
+				return "", 0, btcrpc.ErrNotBroadcast // one transient blip
+			}
+			return "btc-tx-hash", 100, nil
+		},
+	}
+	cfg := &config.AppConfig{}
+	cfg.Bitcoin.MaxBroadcastAttempts = 3
+	tel := telWithBtc(t, db, btc, cfg)
+
+	id := seed(t, db, model.BtcProcessingStatusPending, "50000", "3000")
+
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+	if got := statusOf(t, db, id); got != model.BtcProcessingStatusPending {
+		t.Fatalf("tick 1: status = %q, want pending", got)
+	}
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("tick 2: %v", err)
+	}
+	if got := statusOf(t, db, id); got != model.BtcProcessingStatusCompleted {
+		t.Fatalf("tick 2: status = %q, want completed: a transient failure must not "+
+			"burn the row", got)
+	}
+}

--- a/internal/store/onchainbtcprocessedtransaction/interface.go
+++ b/internal/store/onchainbtcprocessedtransaction/interface.go
@@ -35,6 +35,9 @@ type IStore interface {
 
 	// Update the status of a BTC processed transaction
 	UpdateStatus(tx *gorm.DB, id int, status model.BtcProcessingStatus) error
+	// ReleaseForRetry returns a claimed row to pending and increments its
+	// attempt count atomically, returning the new total.
+	ReleaseForRetry(tx *gorm.DB, id int) (int, error)
 
 	// UpdateToCompleted updates the status of a BTC processed transaction to processed
 	UpdateToCompleted(tx *gorm.DB, id int, btcTxHash string, networkFee int64) error

--- a/internal/store/onchainbtcprocessedtransaction/onchain_btc_processed_transaction.go
+++ b/internal/store/onchainbtcprocessedtransaction/onchain_btc_processed_transaction.go
@@ -71,6 +71,26 @@ func (s *store) ClaimPendingTransaction(tx *gorm.DB, id int) (bool, error) {
 	return result.RowsAffected == 1, nil
 }
 
+// ReleaseForRetry returns a claimed row to pending and counts the attempt in
+// the SAME statement, so a crash between the two cannot lose the count and let
+// a row retry unboundedly. Returns the new attempt total.
+func (s *store) ReleaseForRetry(tx *gorm.DB, id int) (int, error) {
+	if err := tx.Model(&model.OnchainBtcProcessedTransaction{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"status":     model.BtcProcessingStatusPending,
+			"attempts":   gorm.Expr("attempts + 1"),
+			"updated_at": time.Now(),
+		}).Error; err != nil {
+		return 0, err
+	}
+	var row model.OnchainBtcProcessedTransaction
+	if err := tx.Select("attempts").First(&row, "id = ?", id).Error; err != nil {
+		return 0, err
+	}
+	return row.Attempts, nil
+}
+
 func (s *store) UpdateStatus(tx *gorm.DB, id int, status model.BtcProcessingStatus) error {
 	return tx.Model(&model.OnchainBtcProcessedTransaction{}).Where("id = ?", id).Updates(map[string]interface{}{
 		"status":     status,

--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -434,7 +434,34 @@ func (t *Telemetry) processPendingBtcTransactions() error {
 				// DEFINITELY not on the wire (pre-POST error, or a clean
 				// min-relay-fee rejection). No BTC left the treasury: release the
 				// claim (processing -> pending) so a healthy later cycle retries.
-				if rerr := t.store.OnchainBtcProcessedTransaction.UpdateStatus(t.db, pendingTx.ID, model.BtcProcessingStatusPending); rerr != nil {
+				attempts, rerr := t.store.OnchainBtcProcessedTransaction.ReleaseForRetry(t.db, pendingTx.ID)
+				if rerr == nil && t.appConfig.Bitcoin.MaxBroadcastAttempts > 0 &&
+					int64(attempts) >= t.appConfig.Bitcoin.MaxBroadcastAttempts {
+					// Retry budget spent. A pre-POST failure that survives this
+					// many ticks is not transient (empty treasury, every endpoint
+					// down, an amount the network will never take), and the old
+					// code had no bound at all: the row re-failed forever, costing
+					// a UTXO fetch and a fee estimate each time, with the user's
+					// ICY already burned and nothing to alert on.
+					//
+					// "failed", not "needs_reconcile": ErrNotBroadcast means the
+					// tx is DEFINITELY not on the wire, so this is safe and must
+					// not count toward the daily cap.
+					t.logger.Error("[ProcessPendingBtcTransactions][RetryBudgetSpent] giving up, marking failed", map[string]string{
+						"id":       fmt.Sprintf("%d", pendingTx.ID),
+						"attempts": fmt.Sprintf("%d", attempts),
+						"error":    err.Error(),
+					})
+					if uerr := t.store.OnchainBtcProcessedTransaction.UpdateStatus(t.db, pendingTx.ID, model.BtcProcessingStatusFailed); uerr != nil {
+						t.logger.Error("[ProcessPendingBtcTransactions][RetryBudgetSpent][UpdateStatus]", map[string]string{
+							"error": uerr.Error(),
+							"id":    fmt.Sprintf("%d", pendingTx.ID),
+						})
+					}
+					t.emitSwapPayoutWebhook(webhookClient, pendingTx, model.BtcProcessingStatusFailed, amount.Value, "")
+					continue
+				}
+				if rerr != nil {
 					t.logger.Error("[ProcessPendingBtcTransactions][ReleaseClaim]", map[string]string{
 						"error": rerr.Error(),
 						"id":    fmt.Sprintf("%d", pendingTx.ID),

--- a/internal/utils/config/config.go
+++ b/internal/utils/config/config.go
@@ -135,6 +135,11 @@ type BitcoinConfig struct {
 	BlockstreamAPIURLs []string // Multiple endpoints for high availability
 	MaxTxFeeUSD        float64
 	ServiceFeeRate     float64
+	// MaxBroadcastAttempts bounds release-to-pending retries. 0 = unbounded
+	// (the old behaviour), which is what let a permanently-unsendable row spin
+	// forever. Deliberately small: a failure that survives this many ticks is
+	// not transient.
+	MaxBroadcastAttempts int64
 	MinSatshiFee       int64
 	// MinBtcConfirmations is how many on-chain confirmations an outgoing BTC
 	// payout must reach before it is marked completed (confirm-before-complete).
@@ -211,6 +216,7 @@ func New() *AppConfig {
 			BlockstreamAPIURLs:    parseEndpoints(os.Getenv("BTC_BLOCKSTREAM_API_URLS"), os.Getenv("BTC_BLOCKSTREAM_API_URL")),
 			MaxTxFeeUSD:           envVarAsFloat("BTC_MAX_TX_FEE_USD", 1.0),
 			ServiceFeeRate:        envVarAsFloat("BTC_SERVICE_FEE_PERCENTAGE", 0.01),
+			MaxBroadcastAttempts:  envVarAsInt64("BTC_MAX_BROADCAST_ATTEMPTS", 10),
 			MinSatshiFee:          envVarAsInt64("BTC_MIN_SATOSHI_FEE", 3000),
 			MinBtcConfirmations:   envVarAsInt64("BTC_MIN_CONFIRMATIONS", 1),
 			StuckTxTimeoutSeconds: envVarAsInt64("BTC_STUCK_TX_TIMEOUT_SECONDS", 10800),
@@ -319,6 +325,9 @@ func New() *AppConfig {
 		// the rest live got the placeholder defaults instead, silently, and the
 		// two limits whose entire job is bounding a drain would have been sitting
 		// on sample values while everyone believed they were configured.
+		if v, _ := vc.GetKV("BTC_MAX_BROADCAST_ATTEMPTS"); v != "" {
+			config.Bitcoin.MaxBroadcastAttempts, _ = strconv.ParseInt(v, 10, 64)
+		}
 		if v, _ := vc.GetKV("BTC_MAX_PAYOUT_SATOSHI"); v != "" {
 			config.Bitcoin.MaxPayoutSatoshi, _ = strconv.ParseInt(v, 10, 64)
 		}

--- a/migrations/schema/0014_add_attempts_to_btc_processed.down.sql
+++ b/migrations/schema/0014_add_attempts_to_btc_processed.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE onchain_btc_processed_transactions
+DROP COLUMN IF EXISTS attempts;

--- a/migrations/schema/0014_add_attempts_to_btc_processed.up.sql
+++ b/migrations/schema/0014_add_attempts_to_btc_processed.up.sql
@@ -1,0 +1,10 @@
+-- A payout that fails before the broadcast POST is released back to "pending"
+-- and retried on the next settlement tick. Nothing bounded that, so a row whose
+-- failure is permanent (treasury empty, endpoints down, an amount the network
+-- will never accept) re-failed forever, burning a UTXO fetch and a fee estimate
+-- every tick with the user's ICY already burned.
+--
+-- DEFAULT 0 and NOT NULL so existing rows start at zero and the retry budget
+-- applies to them from the next tick onwards.
+ALTER TABLE onchain_btc_processed_transactions
+ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
The last open item from the swap security review.

## The gap

A pre-POST failure releases the row to `pending` so a healthy later tick can retry. That is correct , `ErrNotBroadcast` means no BTC left the treasury, so retrying is safe. But **nothing bounded it**.

A permanently unsendable row (empty treasury, every endpoint down, an amount the network will never take) re-failed on every settlement tick forever: a UTXO fetch and a fee estimate burned each time, with the user's ICY already burned and no terminal state for anyone to alert on. The dust fix in #48 closed one cause; this closes the class.

## The change

`attempts` column (migration 0014, `DEFAULT 0 NOT NULL` so existing rows start clean), incremented in the **same statement** as the release, so a crash between the two cannot lose the count and hand the row an unbounded budget.

Past `BTC_MAX_BROADCAST_ATTEMPTS` (default 10, `0` disables) the row goes to **`failed`**, not `needs_reconcile`. `ErrNotBroadcast` means the tx is definitively not on the wire, so `failed` is the accurate state and keeps the row out of the daily-cap sum , using `needs_reconcile` here would have recreated the ratchet #48 just fixed.

## Tests, both directions

- `RetryBudget_EventuallyGivesUp` , budget spends, row goes terminal, and a later tick does **not** pick it up again.
- `RetryBudget_TransientFailureStillRetries` , one blip then success still completes. A bound that burns rows on a transient failure would be worse than no bound.

Negative control run with the fix committed first (so the restore returns *to* the fix): disabling the bound fails `EventuallyGivesUp` and leaves the transient test passing, which is the correct split. Whole repo green.

## Security review: everything is now closed

For the record, the two remaining unknowns are resolved:

- **On-chain replay protection EXISTS.** `dwarvesf/df-contracts`, `icy-btc/src/IcyBtcSwap.sol:72`: `require(!swappedHashes[swapHash], "ALREADY_PROCESSED")`, over a hash covering `(icyAmount, btcAddress, btcAmount, nonce, deadline)`. **Not Critical.**
- **The Flow B drain is already gone.** A 2026-07-08 review found `ProcessSwapRequests` re-swapping a pending row every 2 minutes with a fresh nonce, defeating `swappedHashes` , one request, a BTC payout forever. That code path no longer exists: it survives only in `docs/sessions/` planning notes, and the route group exposes only `/swap/generate-signature` and `/swap/info`. The `swaprequest` store is now orphaned and worth deleting separately.