### PR TITLE
fix(swap): audit hardening batch, indexer range fix, swap notifications

### DIFF
--- a/internal/baserpc/baserpc.go
+++ b/internal/baserpc/baserpc.go
@@ -467,6 +467,31 @@ func (b *BaseRPC) ICYTransferredTo(txHash string, to common.Address) (*big.Int, 
 	return SumICYTransfersTo(receipt.Logs, icyToken, to)
 }
 
+// blockRanges splits [startBlock, latestBlock] (inclusive on both ends) into
+// contiguous, non-overlapping chunks that each cover AT MOST maxRange blocks
+// inclusive.
+//
+// eth_getLogs fromBlock/toBlock are inclusive, and the public Base RPCs cap a
+// single query at exactly maxRange (10,000) blocks: a span of maxRange+1 is
+// rejected with -32614. So each chunk ends at start+maxRange-1 (clamped to
+// latestBlock), and the next chunk begins at the previous end + 1. The old code
+// used start+maxRange, a maxRange+1-block span, which failed against
+// mainnet.base.org on every catch-up batch and stuck the base_rpc breaker open.
+func blockRanges(startBlock, latestBlock, maxRange uint64) [][2]uint64 {
+	var ranges [][2]uint64
+	if maxRange == 0 || startBlock > latestBlock {
+		return ranges
+	}
+	for currentStart := startBlock; currentStart <= latestBlock; currentStart += maxRange {
+		currentEnd := currentStart + maxRange - 1
+		if currentEnd > latestBlock {
+			currentEnd = latestBlock
+		}
+		ranges = append(ranges, [2]uint64{currentStart, currentEnd})
+	}
+	return ranges
+}
+
 func (b *BaseRPC) GetTransactionsByAddress(address string, fromTxId string) ([]model.OnchainIcyTransaction, error) {
 	// Set a longer timeout context for blockchain scanning operations
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -513,11 +538,8 @@ func (b *BaseRPC) GetTransactionsByAddress(address string, fromTxId string) ([]m
 
 	// Process transactions in batches to avoid block range limitation
 	const maxBlockRange = 10000
-	for currentStart := startBlock; currentStart <= latestBlock; currentStart += maxBlockRange {
-		currentEnd := currentStart + maxBlockRange
-		if currentEnd > latestBlock {
-			currentEnd = latestBlock
-		}
+	for _, r := range blockRanges(startBlock, latestBlock, maxBlockRange) {
+		currentStart, currentEnd := r[0], r[1]
 		// Only log block range every 100K blocks to reduce noise
 		if currentStart%100000 == 0 {
 			b.logger.Info("[GetTransactionsByAddress] block range", map[string]string{

--- a/internal/baserpc/block_ranges_test.go
+++ b/internal/baserpc/block_ranges_test.go
@@ -1,0 +1,71 @@
+package baserpc
+
+import "testing"
+
+// The public Base RPC eth_getLogs cap is exactly 10,000 blocks inclusive; a
+// span of 10,001 is rejected with -32614 and, in the Free-tier + catch-up case,
+// sticks the base_rpc circuit breaker open. Every generated chunk must stay at
+// or under the cap.
+func TestBlockRanges_NeverExceedsCap(t *testing.T) {
+	const maxRange = uint64(10000)
+	ranges := blockRanges(1_000_000, 1_045_000, maxRange)
+	if len(ranges) == 0 {
+		t.Fatal("no ranges generated")
+	}
+
+	// Coverage: the chunks span exactly the requested inclusive range.
+	if ranges[0][0] != 1_000_000 {
+		t.Fatalf("first start = %d, want 1000000", ranges[0][0])
+	}
+	if last := ranges[len(ranges)-1][1]; last != 1_045_000 {
+		t.Fatalf("last end = %d, want 1045000", last)
+	}
+
+	var sawFullChunk bool
+	for i, r := range ranges {
+		width := r[1] - r[0] + 1 // inclusive span
+		if width > maxRange {
+			t.Fatalf("chunk %d spans %d blocks (%d..%d), exceeds the %d-block cap", i, width, r[0], r[1], maxRange)
+		}
+		if width == maxRange {
+			sawFullChunk = true
+		}
+		if i > 0 {
+			if prevEnd := ranges[i-1][1]; r[0] != prevEnd+1 {
+				t.Fatalf("chunk %d starts at %d, want %d (gap or overlap)", i, r[0], prevEnd+1)
+			}
+		}
+	}
+	if !sawFullChunk {
+		t.Fatal("expected at least one full 10000-block chunk")
+	}
+}
+
+// Negative control for the off-by-one that caused the outage: a full inclusive
+// 10000-block span is one chunk; adding a single block forces a second chunk,
+// never a 10001-block span.
+func TestBlockRanges_ExactBoundary(t *testing.T) {
+	const maxRange = uint64(10000)
+
+	// [0, 9999] is exactly 10000 blocks inclusive: a single chunk.
+	one := blockRanges(0, 9999, maxRange)
+	if len(one) != 1 || one[0] != [2]uint64{0, 9999} {
+		t.Fatalf("blockRanges(0,9999) = %v, want a single chunk [0,9999]", one)
+	}
+
+	// [0, 10000] is 10001 blocks: must split into two chunks, NOT emit one
+	// 10001-block span (which is what the pre-fix start+maxRange formula did).
+	two := blockRanges(0, 10000, maxRange)
+	if len(two) != 2 || two[0] != [2]uint64{0, 9999} || two[1] != [2]uint64{10000, 10000} {
+		t.Fatalf("blockRanges(0,10000) = %v, want [[0,9999],[10000,10000]]", two)
+	}
+}
+
+func TestBlockRanges_Empty(t *testing.T) {
+	if r := blockRanges(100, 50, 10000); len(r) != 0 {
+		t.Fatalf("start>latest should yield no ranges, got %v", r)
+	}
+	if r := blockRanges(0, 100, 0); len(r) != 0 {
+		t.Fatalf("zero maxRange should yield no ranges, got %v", r)
+	}
+}

--- a/internal/btcrpc/hardening_test.go
+++ b/internal/btcrpc/hardening_test.go
@@ -1,0 +1,152 @@
+package btcrpc
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+
+	"github.com/dwarvesf/icy-backend/internal/btcrpc/blockstream"
+)
+
+// deriveP2WPKHAddress makes a fresh, valid P2WPKH address for the given network
+// from a random key, so tests never embed a private key or a hardcoded address.
+func deriveP2WPKHAddress(t *testing.T, params *chaincfg.Params) *btcutil.AddressWitnessPubKeyHash {
+	t.Helper()
+	priv, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	pubKeyHash := btcutil.Hash160(priv.PubKey().SerializeCompressed())
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(pubKeyHash, params)
+	if err != nil {
+		t.Fatalf("derive address: %v", err)
+	}
+	return addr
+}
+
+// Item 5: a zero or dust change output is omitted (1 output), so the tx stays
+// broadcastable; an above-dust change produces the usual 2 outputs.
+func TestPrepareTxOutputs_OmitsDustChange(t *testing.T) {
+	params := &chaincfg.MainNetParams
+	b := &BtcRpc{networkParam: params}
+	receiver := deriveP2WPKHAddress(t, params)
+	sender := deriveP2WPKHAddress(t, params)
+	const amountToSend = int64(100_000)
+
+	cases := []struct {
+		name        string
+		changeAmt   int64
+		wantOutputs int
+	}{
+		{"zero change omitted", 0, 1},
+		{"below-dust change omitted", 300, 1},
+		{"at dust threshold kept", dustChangeThreshold, 2}, // 546 is not below dust
+		{"above-dust change kept", 1000, 2},                // negative control
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			outputs, err := b.prepareTxOutputs(receiver, sender, amountToSend, tc.changeAmt)
+			if err != nil {
+				t.Fatalf("prepareTxOutputs: %v", err)
+			}
+			if len(outputs) != tc.wantOutputs {
+				t.Fatalf("outputs = %d, want %d", len(outputs), tc.wantOutputs)
+			}
+			// The recipient output is always present and unchanged.
+			if outputs[0].Value != amountToSend {
+				t.Fatalf("recipient value = %d, want %d", outputs[0].Value, amountToSend)
+			}
+		})
+	}
+}
+
+// mkUTXO builds a UTXO with the given value and confirmation state without naming
+// the inline anonymous Status struct.
+func mkUTXO(value int64, confirmed bool) blockstream.UTXO {
+	u := blockstream.UTXO{Value: value}
+	u.Status.Confirmed = confirmed
+	return u
+}
+
+// selectGreedy mirrors selectUTXOs's selection loop (accumulate in order until
+// the target is covered), so a test over the ORDERED list proves the same
+// preference production applies. Fee only raises the target, never reorders.
+func selectGreedy(ordered []blockstream.UTXO, target int64) []blockstream.UTXO {
+	var total int64
+	var selected []blockstream.UTXO
+	for _, u := range ordered {
+		selected = append(selected, u)
+		total += u.Value
+		if total >= target {
+			break
+		}
+	}
+	return selected
+}
+
+func countUnconfirmed(utxos []blockstream.UTXO) int {
+	n := 0
+	for _, u := range utxos {
+		if !u.Status.Confirmed {
+			n++
+		}
+	}
+	return n
+}
+
+// Item 6: ordering puts confirmed first (value desc), then unconfirmed
+// self-change (value desc).
+func TestOrderSpendableUTXOs_ConfirmedFirst(t *testing.T) {
+	in := []blockstream.UTXO{
+		mkUTXO(500, false),  // unconfirmed
+		mkUTXO(3000, true),  // confirmed
+		mkUTXO(1000, false), // unconfirmed
+		mkUTXO(2000, true),  // confirmed
+	}
+	got := orderSpendableUTXOs(in)
+
+	wantValues := []int64{3000, 2000, 1000, 500}
+	wantConfirmed := []bool{true, true, false, false}
+	if len(got) != len(wantValues) {
+		t.Fatalf("len = %d, want %d", len(got), len(wantValues))
+	}
+	for i := range got {
+		if got[i].Value != wantValues[i] || got[i].Status.Confirmed != wantConfirmed[i] {
+			t.Fatalf("pos %d = {value %d, confirmed %v}, want {value %d, confirmed %v}",
+				i, got[i].Value, got[i].Status.Confirmed, wantValues[i], wantConfirmed[i])
+		}
+	}
+}
+
+// Item 6, order 1 (negative control): when confirmed funds alone cover the
+// payout, the greedy selector never reaches the unconfirmed self-change.
+func TestSelection_SufficientConfirmed_LeavesUnconfirmedUntouched(t *testing.T) {
+	ordered := orderSpendableUTXOs([]blockstream.UTXO{
+		mkUTXO(5000, true),  // confirmed
+		mkUTXO(4000, true),  // confirmed
+		mkUTXO(9000, false), // unconfirmed self-change
+	})
+	selected := selectGreedy(ordered, 6000) // covered by the two confirmed (9000)
+	if n := countUnconfirmed(selected); n != 0 {
+		t.Fatalf("selected %d unconfirmed UTXOs, want 0 (confirmed funds were sufficient)", n)
+	}
+}
+
+// Item 6, order 2: when confirmed funds cannot cover the payout, the selector
+// chains onto the unconfirmed self-change instead of stranding.
+func TestSelection_InsufficientConfirmed_ChainsUnconfirmed(t *testing.T) {
+	ordered := orderSpendableUTXOs([]blockstream.UTXO{
+		mkUTXO(3000, true),  // confirmed
+		mkUTXO(8000, false), // unconfirmed self-change
+	})
+	selected := selectGreedy(ordered, 6000) // 3000 confirmed alone is short
+	if n := countUnconfirmed(selected); n == 0 {
+		t.Fatal("selected 0 unconfirmed UTXOs, want the self-change chained in (confirmed funds were insufficient)")
+	}
+	// Confirmed is still spent first.
+	if !selected[0].Status.Confirmed {
+		t.Fatal("first selected UTXO is unconfirmed; confirmed funds must be preferred")
+	}
+}

--- a/internal/btcrpc/helper.go
+++ b/internal/btcrpc/helper.go
@@ -29,6 +29,15 @@ const (
 	txOverhead       = 10 // Transaction overhead
 )
 
+// dustChangeThreshold is the change-output floor, in satoshi. A change output at
+// or below this is uneconomical (its own future spend costs more than it holds)
+// and standard relay rules reject it as dust, which would make the whole payout
+// unbroadcastable. 546 is the conservative P2PKH dust bound (the highest across
+// address types), so using it here never leaves a truly-spendable change output
+// behind. Change below it is folded into the miner fee (by omitting the output)
+// rather than created.
+const dustChangeThreshold = 546
+
 // calculateTxFee estimates the transaction fee based on current network conditions
 func (b *BtcRpc) calculateTxFee(feeRates map[string]float64, numInputs, numOutputs, targetBlocks int) (int64, error) {
 	// Get fee rate for target blocks
@@ -111,6 +120,15 @@ func (b *BtcRpc) prepareTxOutputs(
 		return nil, fmt.Errorf("failed to create recipient output script: %v", err)
 	}
 	recipientOutput := wire.NewTxOut(amountToSend, pkScript)
+
+	// Omit a zero or dust change output. A change output at or below the dust
+	// threshold is uneconomical and rejected by relay rules, which would make the
+	// whole tx unbroadcastable. Dropping it folds the remainder into the miner fee
+	// (inputs - amountToSend is what the network takes), which is the standard way
+	// to handle sub-dust change.
+	if changeAmount < dustChangeThreshold {
+		return []*wire.TxOut{recipientOutput}, nil
+	}
 
 	// Prepare change output
 	changeAddress, err := btcutil.DecodeAddress(senderAddress.EncodeAddress(), b.networkParam)
@@ -268,7 +286,41 @@ func (b *BtcRpc) verifyAndSelectUTXOs(address string, amountToSend, txFee int64)
 	return nil, false
 }
 
-func (b *BtcRpc) getConfirmedUTXOs(address string) ([]blockstream.UTXO, error) {
+// orderSpendableUTXOs returns the treasury's own UTXOs in SELECTION order:
+// confirmed first (value desc), then unconfirmed (value desc).
+//
+// Every UTXO passed here was returned by GetUTXOs(treasuryAddress), i.e. the
+// esplora/mempool `/address/{addr}/utxo` set for the treasury's OWN address, so
+// an unconfirmed entry is by construction a change output paying back to the
+// treasury (self-change from a not-yet-confirmed prior payout). That is why no
+// per-UTXO address field is needed: the query address IS the ownership proof.
+//
+// Confirmed-first ordering makes the greedy selector spend confirmed funds first
+// and only chain onto unconfirmed self-change when confirmed funds cannot cover
+// the payout. This stops back-to-back payouts from stranding treasury liquidity
+// in an unconfirmed change output.
+func orderSpendableUTXOs(utxos []blockstream.UTXO) []blockstream.UTXO {
+	var confirmed, unconfirmed []blockstream.UTXO
+	for _, utxo := range utxos {
+		if utxo.Status.Confirmed {
+			confirmed = append(confirmed, utxo)
+		} else {
+			unconfirmed = append(unconfirmed, utxo)
+		}
+	}
+	sort.Slice(confirmed, func(i, j int) bool { return confirmed[i].Value > confirmed[j].Value })
+	sort.Slice(unconfirmed, func(i, j int) bool { return unconfirmed[i].Value > unconfirmed[j].Value })
+
+	ordered := make([]blockstream.UTXO, 0, len(confirmed)+len(unconfirmed))
+	ordered = append(ordered, confirmed...)
+	ordered = append(ordered, unconfirmed...)
+	return ordered
+}
+
+// getSpendableUTXOs fetches the treasury address's UTXO set and returns it in
+// selection order (see orderSpendableUTXOs): confirmed first, then unconfirmed
+// self-change as a fallback.
+func (b *BtcRpc) getSpendableUTXOs(address string) ([]blockstream.UTXO, error) {
 	var utxos []blockstream.UTXO
 	err := b.withRetry(func(bs blockstream.IBlockStream) error {
 		var err error
@@ -279,18 +331,7 @@ func (b *BtcRpc) getConfirmedUTXOs(address string) ([]blockstream.UTXO, error) {
 		return nil, err
 	}
 
-	// Filter confirmed UTXOs and sort by value in descending order
-	var confirmedUTXOs []blockstream.UTXO
-	for _, utxo := range utxos {
-		if utxo.Status.Confirmed {
-			confirmedUTXOs = append(confirmedUTXOs, utxo)
-		}
-	}
-	sort.Slice(confirmedUTXOs, func(i, j int) bool {
-		return confirmedUTXOs[i].Value > confirmedUTXOs[j].Value
-	})
-
-	return confirmedUTXOs, nil
+	return orderSpendableUTXOs(utxos), nil
 }
 
 // selectUTXOs picks UTXOs until we have enough to cover amountToSend + fee
@@ -298,7 +339,10 @@ func (b *BtcRpc) getConfirmedUTXOs(address string) ([]blockstream.UTXO, error) {
 // change amount is the amount sent back to sender after sending total amount of selected UTXOs to recipient
 // changeAmount = total amount of selected UTXOs - amountToSend - fee
 func (b *BtcRpc) selectUTXOs(address string, amountToSend int64) (selected []blockstream.UTXO, changeAmount int64, fee int64, err error) {
-	confirmedUTXOs, err := b.getConfirmedUTXOs(address)
+	// Confirmed UTXOs first, then unconfirmed self-change as a fallback, so a
+	// back-to-back payout can chain onto its own not-yet-confirmed change instead
+	// of stranding on "insufficient funds" (see orderSpendableUTXOs).
+	spendableUTXOs, err := b.getSpendableUTXOs(address)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -317,7 +361,7 @@ func (b *BtcRpc) selectUTXOs(address string, amountToSend int64) (selected []blo
 	// Iteratively select UTXOs until we have enough to cover amount + fee
 	var totalSelected int64
 
-	for _, utxo := range confirmedUTXOs {
+	for _, utxo := range spendableUTXOs {
 		selected = append(selected, utxo)
 		totalSelected += utxo.Value
 

--- a/internal/handler/swap/swap.go
+++ b/internal/handler/swap/swap.go
@@ -36,6 +36,13 @@ type GenerateSignatureRequest struct {
 	// turned on, so the frontend can deploy before enforcement begins.
 	WalletSignature string `json:"wallet_signature"`
 	WalletDeadline  int64  `json:"wallet_deadline"`
+
+	// WalletNonce is an OPTIONAL bytes32 (0x + 64 hex) mixed into the signed
+	// SwapRequest for replay hardening. When present, the EIP-712 payload gains a
+	// 4th "nonce" field and a repeat of the same signed nonce is rejected. When
+	// absent, the legacy 3-field digest is used unchanged, so the frontend can
+	// start sending a nonce only after this deploys (deploy sequencing).
+	WalletNonce string `json:"wallet_nonce"`
 }
 
 // oracleRateToleranceNum/Denom bound how far above the oracle-derived amount a

--- a/internal/handler/swap/walletauth.go
+++ b/internal/handler/swap/walletauth.go
@@ -116,6 +116,97 @@ func (l *walletRateLimiter) allow(wallet string) bool {
 // signatures faster than walletRatePerMinute.
 var ErrWalletRateLimited = errors.New("too many signature requests for this wallet")
 
+// ErrWalletAuthReplay is returned when a wallet re-submits a signature that
+// carries a nonce already seen for that wallet.
+var ErrWalletAuthReplay = errors.New("wallet signature nonce has already been used")
+
+const (
+	// nonceSlack is added to the signature deadline to decide how long a used
+	// nonce is remembered. It only needs to outlive the signature's own validity
+	// (deadline), after which RecoverSwapRequestSignerWithNonce rejects it as
+	// expired anyway, so a small slack is enough.
+	nonceSlack = 1 * time.Minute
+	// nonceSweepInterval is how often expired nonces are purged.
+	nonceSweepInterval = 1 * time.Minute
+)
+
+// nonceReplayGuard remembers (wallet,nonce) pairs until their signature expires
+// so a signed request carrying a nonce cannot be replayed.
+//
+// CEILING: this is an in-PROCESS set. It protects a SINGLE replica only; two
+// replicas do not share it, so the same nonce could be replayed once per
+// replica. If this service is ever scaled past one replica, move the seen-nonce
+// set to the database (a UNIQUE (wallet, nonce) row) so the check is global.
+type nonceReplayGuard struct {
+	mu   sync.Mutex
+	seen map[string]time.Time // key -> expiry
+}
+
+// nonceGuard is the process-wide replay set. It is only consulted for requests
+// that actually carry a nonce; legacy nonce-less requests never touch it.
+var nonceGuard = newNonceReplayGuard()
+
+func newNonceReplayGuard() *nonceReplayGuard {
+	g := &nonceReplayGuard{seen: make(map[string]time.Time)}
+	go func() {
+		for {
+			time.Sleep(nonceSweepInterval)
+			g.sweep()
+		}
+	}()
+	return g
+}
+
+// checkAndRecord returns true when key was ALREADY recorded and still unexpired
+// (a replay, reject it); otherwise it records key with the given expiry and
+// returns false (first use, accept it). The read and the write are one locked
+// step so two concurrent replays cannot both pass.
+func (g *nonceReplayGuard) checkAndRecord(key string, expiry time.Time) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	now := time.Now()
+	if exp, ok := g.seen[key]; ok && exp.After(now) {
+		return true
+	}
+	g.seen[key] = expiry
+	return false
+}
+
+func (g *nonceReplayGuard) sweep() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	now := time.Now()
+	for k, exp := range g.seen {
+		if !exp.After(now) {
+			delete(g.seen, k)
+		}
+	}
+}
+
+// normalizeNonce validates a bytes32 nonce (0x + exactly 64 hex chars) and
+// returns it lowercased. An empty input means "no nonce" and is valid (ok=true,
+// nonce=""). Any malformed non-empty input is rejected (ok=false).
+func normalizeNonce(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", true
+	}
+	if !strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X") {
+		return "", false
+	}
+	hexPart := s[2:]
+	if len(hexPart) != 64 {
+		return "", false
+	}
+	for _, c := range hexPart {
+		isHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+		if !isHex {
+			return "", false
+		}
+	}
+	return "0x" + strings.ToLower(hexPart), true
+}
+
 // ErrInsufficientICY is returned when the recovered wallet does not hold the
 // ICY it is asking to swap. This is an anti-Sybil gate, not the swap authority.
 var ErrInsufficientICY = errors.New("wallet does not hold enough ICY for this swap")
@@ -137,12 +228,20 @@ func (h *handler) authenticateCaller(req *GenerateSignatureRequest) (string, err
 		return "", nil
 	}
 
-	addr, err := RecoverSwapRequestSigner(
+	// A malformed nonce is rejected before any recovery or RPC. An empty nonce
+	// is valid and selects the legacy 3-field digest.
+	nonce, ok := normalizeNonce(req.WalletNonce)
+	if !ok {
+		return "", ErrWalletAuthInvalid
+	}
+
+	addr, err := RecoverSwapRequestSignerWithNonce(
 		h.appConfig.ApiServer.WalletAuthChainID,
 		h.appConfig.Blockchain.ICYSwapContractAddr,
 		req.ICYAmount,
 		req.BTCAddress,
 		req.WalletDeadline,
+		nonce,
 		req.WalletSignature,
 	)
 	if err != nil {
@@ -165,6 +264,17 @@ func (h *handler) authenticateCaller(req *GenerateSignatureRequest) (string, err
 
 	if !walletLimiter.allow(wallet) {
 		return "", ErrWalletRateLimited
+	}
+
+	// Replay gate: only requests that carry a nonce are protected. The check runs
+	// AFTER the ICY-balance and rate-limit gates, so an attacker must already hold
+	// ICY and be within the per-wallet rate limit to insert a nonce, which bounds
+	// how fast the seen-set can grow (entries also expire at deadline+slack).
+	if nonce != "" {
+		expiry := time.Unix(req.WalletDeadline, 0).Add(nonceSlack)
+		if nonceGuard.checkAndRecord(wallet+":"+nonce, expiry) {
+			return "", ErrWalletAuthReplay
+		}
 	}
 	return wallet, nil
 }
@@ -209,13 +319,34 @@ func (h *handler) requireSufficientICY(wallet string, icyAmount string) error {
 // swapRequestTypedData rebuilds the exact EIP-712 payload the client signed.
 // Any divergence here (field order, types, domain) changes the digest and the
 // recovered address, so this is the single source of truth for both sides.
+//
+// A non-empty nonce adds a 4th "nonce" (bytes32) field to the SwapRequest and
+// carries it in the message; an empty nonce reproduces the legacy 3-field
+// payload BYTE-FOR-BYTE (same field set, same order), so a client that signs no
+// nonce still recovers exactly as before.
 func swapRequestTypedData(
 	chainID int64,
 	verifyingContract string,
 	icyAmount string,
 	btcAddress string,
 	deadline int64,
+	nonce string,
 ) apitypes.TypedData {
+	fields := []apitypes.Type{
+		{Name: "icyAmount", Type: "uint256"},
+		{Name: "btcAddress", Type: "string"},
+		{Name: "deadline", Type: "uint256"},
+	}
+	message := apitypes.TypedDataMessage{
+		"icyAmount":  icyAmount,
+		"btcAddress": btcAddress,
+		"deadline":   fmt.Sprintf("%d", deadline),
+	}
+	if nonce != "" {
+		fields = append(fields, apitypes.Type{Name: "nonce", Type: "bytes32"})
+		message["nonce"] = nonce
+	}
+
 	return apitypes.TypedData{
 		Types: apitypes.Types{
 			"EIP712Domain": []apitypes.Type{
@@ -224,11 +355,7 @@ func swapRequestTypedData(
 				{Name: "chainId", Type: "uint256"},
 				{Name: "verifyingContract", Type: "address"},
 			},
-			"SwapRequest": []apitypes.Type{
-				{Name: "icyAmount", Type: "uint256"},
-				{Name: "btcAddress", Type: "string"},
-				{Name: "deadline", Type: "uint256"},
-			},
+			"SwapRequest": fields,
 		},
 		PrimaryType: "SwapRequest",
 		Domain: apitypes.TypedDataDomain{
@@ -237,16 +364,13 @@ func swapRequestTypedData(
 			ChainId:           (*math.HexOrDecimal256)(big.NewInt(chainID)),
 			VerifyingContract: verifyingContract,
 		},
-		Message: apitypes.TypedDataMessage{
-			"icyAmount":  icyAmount,
-			"btcAddress": btcAddress,
-			"deadline":   fmt.Sprintf("%d", deadline),
-		},
+		Message: message,
 	}
 }
 
-// RecoverSwapRequestSigner verifies sig over the SwapRequest fields and returns
-// the wallet address that produced it.
+// RecoverSwapRequestSigner verifies sig over the legacy 3-field SwapRequest and
+// returns the wallet address that produced it. Unchanged digest: this is the
+// path a client that signs no nonce takes.
 //
 // The signed payload covers icyAmount and btcAddress, so a captured signature
 // cannot be repurposed for a different amount or a different payout address,
@@ -257,6 +381,23 @@ func RecoverSwapRequestSigner(
 	icyAmount string,
 	btcAddress string,
 	deadline int64,
+	sig string,
+) (common.Address, error) {
+	return RecoverSwapRequestSignerWithNonce(chainID, verifyingContract, icyAmount, btcAddress, deadline, "", sig)
+}
+
+// RecoverSwapRequestSignerWithNonce is RecoverSwapRequestSigner plus an optional
+// bytes32 nonce mixed into the signed payload. An empty nonce yields the legacy
+// 3-field digest (identical to RecoverSwapRequestSigner); a non-empty nonce
+// yields the 4-field digest. The nonce itself is NOT validated here (the caller
+// normalizes/validates its shape); this only binds it into the recovered digest.
+func RecoverSwapRequestSignerWithNonce(
+	chainID int64,
+	verifyingContract string,
+	icyAmount string,
+	btcAddress string,
+	deadline int64,
+	nonce string,
 	sig string,
 ) (common.Address, error) {
 	var zero common.Address
@@ -291,7 +432,7 @@ func RecoverSwapRequestSigner(
 		return zero, ErrWalletAuthInvalid
 	}
 
-	typed := swapRequestTypedData(chainID, verifyingContract, icyAmount, btcAddress, deadline)
+	typed := swapRequestTypedData(chainID, verifyingContract, icyAmount, btcAddress, deadline, nonce)
 
 	domainSeparator, err := typed.HashStruct("EIP712Domain", typed.Domain.Map())
 	if err != nil {

--- a/internal/handler/swap/walletauth_authcaller_test.go
+++ b/internal/handler/swap/walletauth_authcaller_test.go
@@ -1,0 +1,59 @@
+package swap
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/dwarvesf/icy-backend/internal/model"
+	"github.com/dwarvesf/icy-backend/internal/types/environments"
+	"github.com/dwarvesf/icy-backend/internal/utils/config"
+	"github.com/dwarvesf/icy-backend/internal/utils/logger"
+)
+
+// authMockBaseRPC is a minimal baserpc.IBaseRPC double. Only ICYBalanceOf is
+// exercised by authenticateCaller (via requireSufficientICY); it returns a
+// balance large enough to clear the anti-Sybil gate so the test focuses on the
+// nonce/replay path. Every other method is an unused stub.
+type authMockBaseRPC struct {
+	balance string
+}
+
+func (m *authMockBaseRPC) ICYBalanceOf(string) (*model.Web3BigInt, error) {
+	return &model.Web3BigInt{Value: m.balance, Decimal: 18}, nil
+}
+func (m *authMockBaseRPC) Client() *ethclient.Client          { return nil }
+func (m *authMockBaseRPC) GetContractAddress() common.Address { return common.Address{} }
+func (m *authMockBaseRPC) ICYTotalSupply() (*model.Web3BigInt, error) {
+	return &model.Web3BigInt{Value: "0", Decimal: 18}, nil
+}
+func (m *authMockBaseRPC) ICYTransferredTo(string, common.Address) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+func (m *authMockBaseRPC) GetTransactionsByAddress(string, string) ([]model.OnchainIcyTransaction, error) {
+	return nil, nil
+}
+func (m *authMockBaseRPC) Swap(*model.Web3BigInt, string, *model.Web3BigInt) (*types.Transaction, error) {
+	return nil, nil
+}
+func (m *authMockBaseRPC) GenerateSignature(*model.Web3BigInt, string, *model.Web3BigInt, *big.Int, *big.Int) (string, error) {
+	return "", nil
+}
+
+// newAuthTestHandler builds a handler whose config matches the test EIP-712
+// domain (testChainID / testContract) and whose baseRPC reports a large ICY
+// balance, so authenticateCaller reaches the nonce/replay logic.
+func newAuthTestHandler(t *testing.T) *handler {
+	t.Helper()
+	cfg := &config.AppConfig{}
+	cfg.ApiServer.WalletAuthChainID = testChainID
+	cfg.Blockchain.ICYSwapContractAddr = testContract
+	return &handler{
+		logger:    logger.New(environments.Test),
+		appConfig: cfg,
+		baseRPC:   &authMockBaseRPC{balance: "1000000000000000000000"},
+	}
+}

--- a/internal/handler/swap/walletauth_test.go
+++ b/internal/handler/swap/walletauth_test.go
@@ -185,3 +185,223 @@ func TestRecoverSwapRequestSigner_Rejects(t *testing.T) {
 		})
 	}
 }
+
+// mkNonce assembles a valid bytes32 nonce (0x + 64 hex) from a short tag, so no
+// 64-char hex literal appears in the source.
+func mkNonce(tag string) string {
+	return "0x" + strings.Repeat("0", 64-len(tag)) + tag
+}
+
+// signAsWalletWithNonce is signAsWallet plus the 4th bytes32 "nonce" field, so
+// the digest matches the 4-field path in RecoverSwapRequestSignerWithNonce. Like
+// signAsWallet it is an INDEPENDENT construction of the digest.
+func signAsWalletWithNonce(t *testing.T, key string, deadline int64, nonce string) string {
+	t.Helper()
+
+	priv, err := crypto.HexToECDSA(key)
+	if err != nil {
+		t.Fatalf("bad test key: %v", err)
+	}
+
+	typed := apitypes.TypedData{
+		Types: apitypes.Types{
+			"EIP712Domain": []apitypes.Type{
+				{Name: "name", Type: "string"},
+				{Name: "version", Type: "string"},
+				{Name: "chainId", Type: "uint256"},
+				{Name: "verifyingContract", Type: "address"},
+			},
+			"SwapRequest": []apitypes.Type{
+				{Name: "icyAmount", Type: "uint256"},
+				{Name: "btcAddress", Type: "string"},
+				{Name: "deadline", Type: "uint256"},
+				{Name: "nonce", Type: "bytes32"},
+			},
+		},
+		PrimaryType: "SwapRequest",
+		Domain: apitypes.TypedDataDomain{
+			Name:              "IcySwap",
+			Version:           "1",
+			ChainId:           (*math.HexOrDecimal256)(big.NewInt(testChainID)),
+			VerifyingContract: testContract,
+		},
+		Message: apitypes.TypedDataMessage{
+			"icyAmount":  testICY,
+			"btcAddress": testBTCAddr,
+			"deadline":   big.NewInt(deadline).String(),
+			"nonce":      nonce,
+		},
+	}
+
+	domainSep, err := typed.HashStruct("EIP712Domain", typed.Domain.Map())
+	if err != nil {
+		t.Fatalf("domain hash: %v", err)
+	}
+	msgHash, err := typed.HashStruct("SwapRequest", typed.Message)
+	if err != nil {
+		t.Fatalf("message hash: %v", err)
+	}
+
+	digest := crypto.Keccak256([]byte{0x19, 0x01}, domainSep, msgHash)
+	sig, err := crypto.Sign(digest, priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig[64] += 27
+	return "0x" + common_Bytes2Hex(sig)
+}
+
+// A 4-field (nonce) signature recovers to the signer, exactly like the 3-field
+// path. If the nonce were not folded into the digest identically on both sides,
+// this would recover a different address.
+func TestRecoverSwapRequestSignerWithNonce_RoundTrip(t *testing.T) {
+	key, want := testWallet(t)
+	deadline := time.Now().Add(2 * time.Minute).Unix()
+	nonce := mkNonce("ab")
+
+	got, err := RecoverSwapRequestSignerWithNonce(
+		testChainID, testContract, testICY, testBTCAddr, deadline, nonce,
+		signAsWalletWithNonce(t, key, deadline, nonce),
+	)
+	if err != nil {
+		t.Fatalf("valid 4-field signature rejected: %v", err)
+	}
+	if strings.ToLower(got.Hex()) != want {
+		t.Fatalf("recovered %s, want %s", strings.ToLower(got.Hex()), want)
+	}
+}
+
+// A signature signed WITH a nonce must not verify against the legacy 3-field
+// digest, and vice-versa: the two digests are distinct domains.
+func TestRecoverSwapRequestSigner_NonceAndLegacyDigestsDiffer(t *testing.T) {
+	key, want := testWallet(t)
+	deadline := time.Now().Add(2 * time.Minute).Unix()
+	nonce := mkNonce("ab")
+
+	// A nonce-signed signature fed to the legacy (nonce-less) recovery recovers
+	// someone other than the signer.
+	nonceSig := signAsWalletWithNonce(t, key, deadline, nonce)
+	got, err := RecoverSwapRequestSigner(testChainID, testContract, testICY, testBTCAddr, deadline, nonceSig)
+	if err == nil && strings.ToLower(got.Hex()) == want {
+		t.Fatal("nonce-signed signature was accepted by the legacy 3-field digest")
+	}
+
+	// And the reverse: a legacy signature does not verify under the 4-field digest.
+	legacySig := signAsWallet(t, key, deadline)
+	got2, err := RecoverSwapRequestSignerWithNonce(testChainID, testContract, testICY, testBTCAddr, deadline, nonce, legacySig)
+	if err == nil && strings.ToLower(got2.Hex()) == want {
+		t.Fatal("legacy signature was accepted by the 4-field nonce digest")
+	}
+}
+
+func TestNormalizeNonce(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+		out  string
+	}{
+		{"empty is legacy", "", true, ""},
+		{"valid lowercased", "0x" + strings.Repeat("A", 64), true, "0x" + strings.Repeat("a", 64)},
+		{"missing 0x", strings.Repeat("a", 64), false, ""},
+		{"too short", "0x" + strings.Repeat("a", 63), false, ""},
+		{"too long", "0x" + strings.Repeat("a", 65), false, ""},
+		{"non-hex", "0x" + strings.Repeat("g", 64), false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, ok := normalizeNonce(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && out != tc.out {
+				t.Fatalf("out = %q, want %q", out, tc.out)
+			}
+		})
+	}
+}
+
+// The replay guard: a (wallet,nonce) accepted once is rejected on the second
+// call; a DIFFERENT nonce is accepted (negative control); and an entry whose
+// expiry has passed is accepted again (the signature would itself be expired).
+func TestNonceReplayGuard(t *testing.T) {
+	g := &nonceReplayGuard{seen: make(map[string]time.Time)}
+	future := time.Now().Add(1 * time.Minute)
+	nonce := mkNonce("ab")
+
+	if replay := g.checkAndRecord("wallet:"+nonce, future); replay {
+		t.Fatal("first use flagged as replay")
+	}
+	if replay := g.checkAndRecord("wallet:"+nonce, future); !replay {
+		t.Fatal("second use of the same nonce not flagged as replay")
+	}
+	if replay := g.checkAndRecord("wallet:"+mkNonce("cd"), future); replay {
+		t.Fatal("a different nonce was flagged as replay")
+	}
+	// An already-expired entry is treated as not seen (accepted again).
+	g.seen["wallet:expired"] = time.Now().Add(-1 * time.Second)
+	if replay := g.checkAndRecord("wallet:expired", future); replay {
+		t.Fatal("an expired nonce entry was flagged as replay")
+	}
+}
+
+// End-to-end through authenticateCaller: a nonce-bearing request is accepted the
+// first time and rejected as a replay the second time; the legacy no-nonce path
+// still authenticates; a malformed nonce is rejected outright.
+func TestAuthenticateCaller_NoncePathAndReplay(t *testing.T) {
+	key, wantWallet := testWallet(t)
+	h := newAuthTestHandler(t)
+
+	t.Run("nonce accepted once then rejected on replay", func(t *testing.T) {
+		deadline := time.Now().Add(2 * time.Minute).Unix()
+		nonce := mkNonce("11ab")
+		req := &GenerateSignatureRequest{
+			ICYAmount:       testICY,
+			BTCAddress:      testBTCAddr,
+			WalletDeadline:  deadline,
+			WalletNonce:     nonce,
+			WalletSignature: signAsWalletWithNonce(t, key, deadline, nonce),
+		}
+		got, err := h.authenticateCaller(req)
+		if err != nil {
+			t.Fatalf("first use rejected: %v", err)
+		}
+		if got != wantWallet {
+			t.Fatalf("wallet = %s, want %s", got, wantWallet)
+		}
+		if _, err := h.authenticateCaller(req); err != ErrWalletAuthReplay {
+			t.Fatalf("replay error = %v, want ErrWalletAuthReplay", err)
+		}
+	})
+
+	t.Run("legacy no-nonce still authenticates", func(t *testing.T) {
+		deadline := time.Now().Add(2 * time.Minute).Unix()
+		req := &GenerateSignatureRequest{
+			ICYAmount:       testICY,
+			BTCAddress:      testBTCAddr,
+			WalletDeadline:  deadline,
+			WalletSignature: signAsWallet(t, key, deadline),
+		}
+		got, err := h.authenticateCaller(req)
+		if err != nil {
+			t.Fatalf("legacy request rejected: %v", err)
+		}
+		if got != wantWallet {
+			t.Fatalf("wallet = %s, want %s", got, wantWallet)
+		}
+	})
+
+	t.Run("malformed nonce rejected", func(t *testing.T) {
+		deadline := time.Now().Add(2 * time.Minute).Unix()
+		req := &GenerateSignatureRequest{
+			ICYAmount:       testICY,
+			BTCAddress:      testBTCAddr,
+			WalletDeadline:  deadline,
+			WalletNonce:     "0xdeadbeef", // not 32 bytes
+			WalletSignature: signAsWallet(t, key, deadline),
+		}
+		if _, err := h.authenticateCaller(req); err != ErrWalletAuthInvalid {
+			t.Fatalf("malformed nonce error = %v, want ErrWalletAuthInvalid", err)
+		}
+	})
+}

--- a/internal/model/web3_bigint.go
+++ b/internal/model/web3_bigint.go
@@ -16,6 +16,15 @@ func (w *Web3BigInt) Int64() (int64, bool) {
 		return 0, false
 	}
 
+	// big.Int.Int64() silently WRAPS for values outside the int64 range, so a
+	// value above MaxInt64 used to return a bogus (possibly negative) number with
+	// ok=true. Gate on IsInt64() so an out-of-range value fails closed (ok=false)
+	// and the caller treats it as a conversion failure instead of acting on a
+	// wrapped amount.
+	if !amt.IsInt64() {
+		return 0, false
+	}
+
 	return amt.Int64(), true
 }
 

--- a/internal/model/web3_bigint_test.go
+++ b/internal/model/web3_bigint_test.go
@@ -4,6 +4,36 @@ import (
 	"testing"
 )
 
+func TestWeb3BigInt_Int64(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		want   int64
+		wantOK bool
+	}{
+		// Negative control: a small in-range value converts cleanly.
+		{"in range one", "1", 1, true},
+		{"in range max", "9223372036854775807", 9223372036854775807, true}, // MaxInt64
+		// 2^63 is MaxInt64 + 1: out of range. big.Int.Int64() would WRAP this to a
+		// negative number; IsInt64() must instead fail closed.
+		{"overflow 2^63", "9223372036854775808", 0, false},
+		{"far overflow", "100000000000000000000", 0, false},
+		{"unparseable", "not-a-number", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &Web3BigInt{Value: tc.value, Decimal: 8}
+			got, ok := w.Int64()
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("got = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWeb3BigInt_ToFloat(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/server/swap_payout_webhook_test.go
+++ b/internal/server/swap_payout_webhook_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -196,6 +197,56 @@ func TestProcessPending_ReleasedToPending_NoWebhook(t *testing.T) {
 	}
 	if got := statusOf(t, db, id); got != model.BtcProcessingStatusPending {
 		t.Fatalf("status = %q, want pending (released for retry)", got)
+	}
+
+	assertNoPayoutWebhook(t, ch)
+}
+
+// Swap detected: creating the payout row for a verified swap fires a "pending"
+// notification carrying the ICY amount, so the channel hears about a swap when
+// it is detected on-chain, not only when the payout settles.
+func TestCreateBtcPayout_FiresSwapDetectedWebhook(t *testing.T) {
+	srv, ch := captureWebhookServer()
+	defer srv.Close()
+
+	db := newTestDB(t)
+	base := &mockBaseRpc{
+		treasury:  treasuryAddr,
+		deposited: map[string]*big.Int{"0xswapok": big.NewInt(1234)},
+	}
+	cfg := &config.AppConfig{SwapPayoutWebhookURL: srv.URL}
+	tel := telemetry.New(db, store.New(db), cfg, logger.New(environments.Test), nil, base, nil)
+
+	if err := tel.CreateBtcPayoutForSwap(db, swapEvent("0xswapok", "1234", "5000")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	content := waitForPayoutWebhook(t, ch)
+	// pending status, the ICY amount from the swap, the sendable BTC amount
+	// (5000 - 0 fee), and the custom ICY emoji prefix.
+	for _, want := range []string{"pending", "1234", "5000", "<a:icy:1192768878183465062>"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("swap-detected webhook content %q missing %q", content, want)
+		}
+	}
+}
+
+// Negative control: a REJECTED swap (short ICY deposit) creates no payout row,
+// so no swap-detected notification fires.
+func TestCreateBtcPayout_ShortDeposit_NoWebhook(t *testing.T) {
+	srv, ch := captureWebhookServer()
+	defer srv.Close()
+
+	db := newTestDB(t)
+	base := &mockBaseRpc{
+		treasury:  treasuryAddr,
+		deposited: map[string]*big.Int{"0xshort": big.NewInt(500)}, // < required 1000
+	}
+	cfg := &config.AppConfig{SwapPayoutWebhookURL: srv.URL}
+	tel := telemetry.New(db, store.New(db), cfg, logger.New(environments.Test), nil, base, nil)
+
+	if err := tel.CreateBtcPayoutForSwap(db, swapEvent("0xshort", "1000", "5000")); err != nil {
+		t.Fatalf("create: %v", err)
 	}
 
 	assertNoPayoutWebhook(t, ch)

--- a/internal/store/onchainbtcprocessedtransaction/caps_test.go
+++ b/internal/store/onchainbtcprocessedtransaction/caps_test.go
@@ -119,6 +119,81 @@ func TestSumSentInWindow_NeedsReconcileCountedViaUpdatedAt(t *testing.T) {
 	}
 }
 
+// seedRowWithNetFee is seedRowAt plus a recorded network_fee, so the daily-cap
+// sum's inclusion of miner fees can be asserted.
+func seedRowWithNetFee(t *testing.T, db *gorm.DB, status model.BtcProcessingStatus, subtotal, svcFee, netFee string, at time.Time) int {
+	t.Helper()
+	row := &model.OnchainBtcProcessedTransaction{
+		BTCAddress: "bc1qexampleaddr",
+		Subtotal:   subtotal,
+		ServiceFee: svcFee,
+		NetworkFee: netFee,
+		Status:     status,
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed row: %v", err)
+	}
+	if err := db.Exec(`UPDATE onchain_btc_processed_transactions SET processed_at = ?, updated_at = ? WHERE id = ?`, at, at, row.ID).Error; err != nil {
+		t.Fatalf("stamp row: %v", err)
+	}
+	return row.ID
+}
+
+// The rolling sum counts the network (miner) fee as BTC that left the treasury:
+// contribution is (subtotal - service_fee) + network_fee.
+func TestSumSentInWindow_IncludesNetworkFee(t *testing.T) {
+	db := newTestDB(t)
+	s := onchainbtcprocessedtransaction.New()
+	now := time.Now()
+	recent := now.Add(-1 * time.Hour)
+
+	// subtotal 1000 - fee 100 = 900 sendable, plus 50 network fee = 950.
+	seedRowWithNetFee(t, db, model.BtcProcessingStatusCompleted, "1000", "100", "50", recent)
+
+	got, err := s.SumSentInWindow(db, now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("SumSentInWindow: %v", err)
+	}
+	if got != 950 {
+		t.Fatalf("sum = %d, want 950 (900 payout + 50 network fee)", got)
+	}
+}
+
+// Negative control for the network-fee inclusion: the SAME payout with NO
+// recorded network fee contributes only its sendable amount (900). If the fee
+// term were mishandled (e.g. a parse error on empty), this would fail.
+func TestSumSentInWindow_NoNetworkFee_OnlySendableCounted(t *testing.T) {
+	db := newTestDB(t)
+	s := onchainbtcprocessedtransaction.New()
+	now := time.Now()
+	recent := now.Add(-1 * time.Hour)
+
+	seedRowWithNetFee(t, db, model.BtcProcessingStatusCompleted, "1000", "100", "", recent)
+
+	got, err := s.SumSentInWindow(db, now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("SumSentInWindow: %v", err)
+	}
+	if got != 900 {
+		t.Fatalf("sum = %d, want 900 (payout only, no network fee recorded)", got)
+	}
+}
+
+// Fail-closed: an unparseable network_fee returns an error rather than silently
+// under-counting the daily total.
+func TestSumSentInWindow_UnparseableNetworkFeeFailsClosed(t *testing.T) {
+	db := newTestDB(t)
+	s := onchainbtcprocessedtransaction.New()
+	now := time.Now()
+	recent := now.Add(-1 * time.Hour)
+
+	seedRowWithNetFee(t, db, model.BtcProcessingStatusCompleted, "1000", "100", "not-a-number", recent)
+
+	if _, err := s.SumSentInWindow(db, now.Add(-24*time.Hour)); err == nil {
+		t.Fatal("want an error for an unparseable network_fee, got nil (would under-count)")
+	}
+}
+
 // Fail-closed: an unparseable amount returns an error rather than silently
 // under-counting the daily total (which would weaken the cap).
 func TestSumSentInWindow_UnparseableAmountFailsClosed(t *testing.T) {

--- a/internal/store/onchainbtcprocessedtransaction/onchain_btc_processed_transaction.go
+++ b/internal/store/onchainbtcprocessedtransaction/onchain_btc_processed_transaction.go
@@ -155,32 +155,37 @@ var sentStates = []string{
 	string(model.BtcProcessingStatusNeedsReconcile),
 }
 
-// SumSentInWindow returns the total sendable amount, in satoshi, of every payout
-// in a sent state (see sentStates) whose send timestamp falls at or after `since`.
-// The per-row sendable amount is subtotal - service_fee (the exact figure that
-// left, or would have left, the treasury). The send timestamp is processed_at
-// (the broadcast/completion time) when set, else updated_at, so an ambiguous
-// needs_reconcile row that never recorded a broadcast time still counts via its
-// last-update time (conservative). Amounts are stored as strings; a row whose
-// amount cannot be parsed returns an error rather than being skipped, so the
-// caller FAILS CLOSED (refuses the payout) instead of under-counting the daily
-// total. This is the rolling-24h input for the SG-06 daily payout cap.
+// SumSentInWindow returns the total BTC, in satoshi, that left (or may have left)
+// the treasury for every payout in a sent state (see sentStates) whose send
+// timestamp falls at or after `since`.
+//
+// The per-row contribution is (subtotal - service_fee) + network_fee: the payout
+// itself PLUS the miner fee, because both are real BTC leaving the treasury. The
+// old sum omitted the network fee and so under-counted outflow, letting the daily
+// cap trip later than it should. Including it is the conservative direction (the
+// sum grows, the cap trips earlier, never later).
+//
+// The send-time window is pushed into SQL via COALESCE(processed_at, updated_at)
+// >= since: processed_at (the broadcast/completion time) when set, else
+// updated_at, so an ambiguous needs_reconcile row that never recorded a broadcast
+// time still counts via its last-update time (conservative). This bounds the scan
+// to the window instead of loading every sent-state row and filtering in Go.
+//
+// Amounts are stored as strings; a row whose amount cannot be parsed returns an
+// error rather than being skipped, so the caller FAILS CLOSED (refuses the
+// payout) instead of under-counting the daily total. This is the rolling-24h
+// input for the SG-06 daily payout cap.
 func (s *store) SumSentInWindow(tx *gorm.DB, since time.Time) (int64, error) {
 	var rows []model.OnchainBtcProcessedTransaction
-	if err := tx.Where("status IN ?", sentStates).Find(&rows).Error; err != nil {
+	if err := tx.
+		Where("status IN ?", sentStates).
+		Where("COALESCE(processed_at, updated_at) >= ?", since).
+		Find(&rows).Error; err != nil {
 		return 0, err
 	}
 
 	var total int64
 	for _, r := range rows {
-		sentAt := r.UpdatedAt
-		if r.ProcessedAt != nil {
-			sentAt = *r.ProcessedAt
-		}
-		if sentAt.Before(since) {
-			continue
-		}
-
 		subtotal, err := strconv.ParseInt(r.Subtotal, 10, 64)
 		if err != nil {
 			return 0, fmt.Errorf("SumSentInWindow: parse subtotal %q (id %d): %w", r.Subtotal, r.ID, err)
@@ -198,6 +203,21 @@ func (s *store) SumSentInWindow(tx *gorm.DB, since time.Time) (int64, error) {
 			// A negative row never sent BTC; do not let it reduce the running total.
 			amount = 0
 		}
+
+		// Add the recorded network (miner) fee. It is real BTC that left the
+		// treasury alongside the payout. Empty for a row that never recorded a
+		// broadcast (e.g. an ambiguous needs_reconcile that only stamped status),
+		// which counts as 0.
+		if r.NetworkFee != "" {
+			netFee, err := strconv.ParseInt(r.NetworkFee, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("SumSentInWindow: parse network_fee %q (id %d): %w", r.NetworkFee, r.ID, err)
+			}
+			if netFee > 0 {
+				total += netFee
+			}
+		}
+
 		total += amount
 	}
 

--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -403,6 +403,12 @@ func (t *Telemetry) processPendingBtcTransactions() error {
 				t.emitSwapPayoutWebhook(webhookClient, pendingTx, model.BtcProcessingStatusRefused, amount.Value, "")
 				continue
 			}
+			// `sent` now includes the network fee of every prior sent row (see
+			// SumSentInWindow). `amtInt` is only THIS payout's sendable amount
+			// (subtotal - service_fee); its own network fee is unknowable until
+			// broadcast, so it is deliberately left out. That is the conservative
+			// direction: the candidate is under-counted by at most its own fee, so
+			// the cap can only trip earlier, never later.
 			if sent+amtInt > maxDaily {
 				t.logger.Error("[ProcessPendingBtcTransactions][DailyCap] rolling 24h cap would be crossed, refusing (refused, NOT sent)", map[string]string{
 					"id":          fmt.Sprintf("%d", pendingTx.ID),

--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -146,14 +146,25 @@ func (t *Telemetry) emitSwapPayoutWebhook(client *webhook.Client, pendingTx mode
 		icyAmount = swapTx.IcyAmount
 	}
 
-	event := webhook.SwapPayoutEvent{
+	t.fireSwapPayoutWebhook(client, webhook.SwapPayoutEvent{
 		Status:     string(status),
 		IcyAmount:  icyAmount,
 		BtcAmount:  btcAmount,
 		BtcAddress: pendingTx.BTCAddress,
 		BtcTxHash:  btcTxHash,
-	}
+	})
+}
 
+// fireSwapPayoutWebhook posts a pre-built SwapPayoutEvent, fire-and-forget. It is
+// the shared tail of both the terminal-state emit (emitSwapPayoutWebhook) and the
+// swap-detected emit (CreateBtcPayoutForSwap): if no webhook URL is configured it
+// is a no-op, and the HTTP call runs in a detached, bounded-context goroutine so a
+// webhook failure or hang never blocks or errors the caller.
+func (t *Telemetry) fireSwapPayoutWebhook(client *webhook.Client, event webhook.SwapPayoutEvent) {
+	webhookURL := t.appConfig.SwapPayoutWebhookURL
+	if webhookURL == "" {
+		return
+	}
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), swapPayoutWebhookTimeout)
 		defer cancel()

--- a/internal/telemetry/swap.go
+++ b/internal/telemetry/swap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/model"
 	"github.com/dwarvesf/icy-backend/internal/store"
+	"github.com/dwarvesf/icy-backend/internal/utils/webhook"
 )
 
 // IndexIcySwapTransaction fetches and stores Swap events from the contract
@@ -367,6 +368,20 @@ func (t *Telemetry) CreateBtcPayoutForSwap(tx *gorm.DB, swapTx *model.OnchainIcy
 		})
 		return err
 	}
+
+	// Notify that a swap was DETECTED on-chain, so the channel hears about it when
+	// the payout is created (status "pending"), not only when it settles. Built
+	// from swapTx directly (its IcyAmount/BtcAddress and the just-computed sendable
+	// total) rather than a DB lookup, because the swap row is still uncommitted in
+	// this tx. Fire-and-forget: it never blocks or fails the payout creation, and
+	// no BtcTxHash exists yet (nothing broadcast).
+	t.fireSwapPayoutWebhook(webhook.New(t.logger), webhook.SwapPayoutEvent{
+		Status:     string(model.BtcProcessingStatusPending),
+		IcyAmount:  swapTx.IcyAmount,
+		BtcAmount:  totalBig.String(),
+		BtcAddress: swapTx.BtcAddress,
+		BtcTxHash:  "",
+	})
 	return nil
 }
 

--- a/internal/utils/webhook/webhook.go
+++ b/internal/utils/webhook/webhook.go
@@ -71,17 +71,24 @@ func (c *Client) CallUptimeWebhook(ctx context.Context, webhookURL string) {
 	})
 }
 
-// SwapPayoutEvent carries the swap fields for a BTC payout that just reached a
-// terminal settlement state (completed / failed / needs_reconcile). This is
-// detection, not prevention: it exists so a drain or anomaly is visible
-// somewhere other than the in-page browser toast.
+// SwapPayoutEvent carries the swap fields for a BTC payout notification. It fires
+// both when a swap is first DETECTED on-chain (status "pending", the payout row
+// was just created) and when the payout reaches a terminal settlement state
+// (completed / failed / needs_reconcile). This is detection, not prevention: it
+// exists so a swap, drain, or anomaly is visible somewhere other than the
+// in-page browser toast.
 type SwapPayoutEvent struct {
-	Status     string // completed | failed | needs_reconcile
+	Status     string // pending | completed | failed | needs_reconcile
 	IcyAmount  string
 	BtcAmount  string
 	BtcAddress string
 	BtcTxHash  string
 }
+
+// icyEmoji is the Dwarves server's custom animated ICY emoji. Discord renders a
+// literal <a:name:id> token in a message's content field as the emoji, so it can
+// prefix the swap notification directly.
+const icyEmoji = "<a:icy:1192768878183465062>"
 
 // CallSwapPayoutWebhook posts a Discord-formatted notification for a settled
 // BTC payout. Like CallUptimeWebhook, it never returns an error: every failure
@@ -93,8 +100,8 @@ func (c *Client) CallSwapPayoutWebhook(ctx context.Context, webhookURL string, e
 	}
 
 	content := fmt.Sprintf(
-		"BTC payout **%s**\nICY amount: `%s`\nBTC amount: `%s`\nDestination: `%s`\nTx hash: `%s`",
-		event.Status, event.IcyAmount, event.BtcAmount, event.BtcAddress, event.BtcTxHash,
+		"%s BTC payout **%s**\nICY amount: `%s`\nBTC amount: `%s`\nDestination: `%s`\nTx hash: `%s`",
+		icyEmoji, event.Status, event.IcyAmount, event.BtcAmount, event.BtcAddress, event.BtcTxHash,
 	)
 
 	payload, err := json.Marshal(map[string]string{"content": content})

--- a/internal/utils/webhook/webhook_test.go
+++ b/internal/utils/webhook/webhook_test.go
@@ -107,6 +107,33 @@ func TestCallSwapPayoutWebhook_NeedsReconcile_PostsExpectedPayload(t *testing.T)
 	}
 }
 
+// A swap-detected (pending) notification fires with the pending status and is
+// prefixed with the Dwarves custom ICY emoji.
+func TestCallSwapPayoutWebhook_Pending_PrefixesIcyEmoji(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	c.CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
+		Status:     "pending",
+		IcyAmount:  "2000000000000000000",
+		BtcAmount:  "95000",
+		BtcAddress: "bc1qexampleaddr",
+		BtcTxHash:  "",
+	})
+
+	content := gotBody["content"]
+	for _, want := range []string{icyEmoji, "pending", "2000000000000000000", "95000", "bc1qexampleaddr"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("webhook content %q missing %q", content, want)
+		}
+	}
+}
+
 // Graceful degrade: no URL configured means no request is made and no error
 // is raised, matching CallUptimeWebhook's existing contract.
 func TestCallSwapPayoutWebhook_EmptyURL_NoRequest(t *testing.T) {


### PR DESCRIPTION
Hardening batch closing the remaining findings from the 2026-07-20 audit, plus two live-outage fixes and the swap Discord notification.

## Changes
- eth_getLogs range off-by-one: chunks were 10,001 blocks inclusive, over the public Base RPC 10,000 cap (-32614). THIS IS THE LIVE OUTAGE FIX: with the Alchemy account now on Free tier (10-block getLogs cap), a catching-up indexer failed on both providers, holding the base_rpc circuit breaker open and killing the /swap/info rate. Vault has been reordered to mainnet.base.org primary; this fix makes the 10k chunks legal there.
- EIP-712 wallet-auth nonce (optional bytes32): replay-proof within the deadline window via an in-process seen-nonce set (single-replica ceiling documented). Legacy 3-field digest accepted byte-for-byte unchanged; frontend starts sending the nonce in dwarvesf/icy-swap#14 AFTER this deploys.
- Swap DETECTED notification: the payout-created (pending) event now posts to the Discord webhook, so the channel hears when a swap lands on-chain, not only at settlement. Messages prefixed with the custom ICY emoji.
- Web3BigInt.Int64 fails closed on overflow (was silently wrapping).
- Daily-cap window sum: bound pushed into SQL (COALESCE(processed_at, updated_at) >= since) and each sent row now counts its recorded network_fee, so real BTC outflow is what the cap sees. Candidate own fee still excluded pre-broadcast (conservative direction, documented).
- Dust/zero change outputs (<546 sats) folded into fee instead of emitted.
- Treasury UTXO selection: confirmed-first, then unconfirmed self-change (all UTXOs are treasury-owned by construction), so back-to-back payouts no longer strand liquidity.

## Verification
Full go test ./... exit 0 (mise Go 1.24.2). Independent re-run of all touched packages green, including the new negative controls. golangci-lint --new-from-rev=892ce7e: 0 new issues. Live curl proof of the RPC caps: 10,000-block getLogs passes on mainnet.base.org, 10,001 rejects with -32614.

## Deploy notes
1. Merge, tag (v0.4.11) -> prod image builds + kustomize bump.
2. Vault already updated: SWAP_PAYOUT_WEBHOOK_URL set (notifications live), RPC endpoints reordered public-first.
3. After deploy: watch the indexers catch up, breaker close, rate return; then merge icy-swap#14 (frontend nonce).
