### PR TITLE
feat(webhook): include the BTC vault balance in swap notifications

### DIFF
--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -168,6 +168,15 @@ func (t *Telemetry) fireSwapPayoutWebhook(client *webhook.Client, event webhook.
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), swapPayoutWebhookTimeout)
 		defer cancel()
+		// Best-effort vault-balance enrichment, done INSIDE the detached
+		// goroutine so the network read can never slow the settlement or
+		// indexing caller. A failed read (or a test Telemetry with no
+		// btcRpc) just omits the line.
+		if t.btcRpc != nil {
+			if balance, err := t.btcRpc.CurrentBalance(); err == nil && balance != nil {
+				event.VaultBalanceSats = balance.Value
+			}
+		}
 		client.CallSwapPayoutWebhook(ctx, webhookURL, event)
 	}()
 }

--- a/internal/utils/webhook/webhook.go
+++ b/internal/utils/webhook/webhook.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"time"
 
@@ -83,6 +84,11 @@ type SwapPayoutEvent struct {
 	BtcAmount  string
 	BtcAddress string
 	BtcTxHash  string
+	// VaultBalanceSats is the treasury BTC balance in satoshi at post time,
+	// fetched best-effort by the emitter. Empty = the lookup failed or was
+	// skipped; the message simply omits the line rather than showing a stale
+	// or bogus number.
+	VaultBalanceSats string
 }
 
 // icyEmoji is the Dwarves server's custom animated ICY emoji. Discord renders a
@@ -103,6 +109,13 @@ func (c *Client) CallSwapPayoutWebhook(ctx context.Context, webhookURL string, e
 		"%s BTC payout **%s**\nICY amount: `%s`\nBTC amount: `%s`\nDestination: `%s`\nTx hash: `%s`",
 		icyEmoji, event.Status, event.IcyAmount, event.BtcAmount, event.BtcAddress, event.BtcTxHash,
 	)
+	if event.VaultBalanceSats != "" {
+		content += "\nVault balance: `" + event.VaultBalanceSats + " sats`"
+		if sats, ok := new(big.Int).SetString(event.VaultBalanceSats, 10); ok {
+			btc := new(big.Float).Quo(new(big.Float).SetInt(sats), big.NewFloat(1e8))
+			content += fmt.Sprintf(" (~%s BTC)", btc.Text('f', 4))
+		}
+	}
 
 	payload, err := json.Marshal(map[string]string{"content": content})
 	if err != nil {

--- a/internal/utils/webhook/webhook_test.go
+++ b/internal/utils/webhook/webhook_test.go
@@ -211,3 +211,45 @@ func TestCallUptimeWebhook_Success_SendsGet(t *testing.T) {
 func TestCallUptimeWebhook_EmptyURL_NoRequest(t *testing.T) {
 	newTestClient(t).CallUptimeWebhook(context.Background(), "")
 }
+
+func TestCallSwapPayoutWebhook_VaultBalance_AppendsLineWithBtc(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	c.CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
+		Status:           "completed",
+		BtcAmount:        "95000",
+		VaultBalanceSats: "28768896",
+	})
+
+	content := gotBody["content"]
+	for _, want := range []string{"Vault balance", "28768896 sats", "~0.2877 BTC"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("webhook content %q missing %q", content, want)
+		}
+	}
+}
+
+func TestCallSwapPayoutWebhook_NoVaultBalance_OmitsLine(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t)
+	c.CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
+		Status:    "completed",
+		BtcAmount: "95000",
+	})
+
+	if strings.Contains(gotBody["content"], "Vault balance") {
+		t.Fatalf("webhook content %q should omit the vault-balance line", gotBody["content"])
+	}
+}


### PR DESCRIPTION
Han asked to track the BTC vault balance on Discord together with the swaps. Each swap notification now ends with `Vault balance: <sats> sats (~X.XXXX BTC)`, fetched best-effort at post time (in the detached webhook goroutine; a failed read omits the line). Tests: line renders with sats + ~BTC conversion; absent balance omits the line (negative control); nil-btcRpc guard for test telemetries.