### PR TITLE
fix(indexer): give the swap-event scan endpoint failover

### DIFF
--- a/internal/baserpc/baserpc.go
+++ b/internal/baserpc/baserpc.go
@@ -492,6 +492,44 @@ func blockRanges(startBlock, latestBlock, maxRange uint64) [][2]uint64 {
 	return ranges
 }
 
+// FilterSwapEvents scans [startBlock, endBlock] (inclusive) for the swap
+// contract's Swap events WITH endpoint failover. The contract binding is
+// rebuilt from the CURRENT client on every attempt, because withRetry
+// re-dials the shared client when it rotates endpoints: a binding captured
+// once by a caller keeps pointing at the old endpoint forever. That is
+// exactly how the indexer got stuck on a free-tier endpoint that serves
+// eth_call but rejects ranged eth_getLogs, while nothing else failed hard
+// enough to rotate it back.
+func (b *BaseRPC) FilterSwapEvents(startBlock, endBlock uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error) {
+	var events []*icyBtcSwap.IcyBtcSwapSwap
+	err := b.withRetry(func() error {
+		contract, err := icyBtcSwap.NewIcyBtcSwap(b.GetContractAddress(), b.Client())
+		if err != nil {
+			return err
+		}
+		iter, err := contract.FilterSwap(&bind.FilterOpts{
+			Start:   startBlock,
+			End:     &endBlock,
+			Context: context.Background(),
+		})
+		if err != nil {
+			return err
+		}
+		defer iter.Close()
+		events = events[:0]
+		for iter.Next() {
+			if iter.Event != nil {
+				events = append(events, iter.Event)
+			}
+		}
+		return iter.Error()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
 func (b *BaseRPC) GetTransactionsByAddress(address string, fromTxId string) ([]model.OnchainIcyTransaction, error) {
 	// Set a longer timeout context for blockchain scanning operations
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/internal/baserpc/interface.go
+++ b/internal/baserpc/interface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 
+	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/model"
 )
 
@@ -21,6 +22,10 @@ type IBaseRPC interface {
 	// landed in the treasury before any BTC payout row is created.
 	ICYTransferredTo(txHash string, to common.Address) (*big.Int, error)
 	GetTransactionsByAddress(address string, fromTxId string) ([]model.OnchainIcyTransaction, error)
+	// FilterSwapEvents scans [startBlock, endBlock] (inclusive) for the swap
+	// contract's Swap events with endpoint failover; see the implementation
+	// for why callers must NOT build their own binding from Client().
+	FilterSwapEvents(startBlock, endBlock uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error)
 	Swap(
 		icyAmount *model.Web3BigInt,
 		btcAddress string,

--- a/internal/handler/swap/ratecheck/generate_signature_test.go
+++ b/internal/handler/swap/ratecheck/generate_signature_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/handler/swap"
 	"github.com/dwarvesf/icy-backend/internal/model"
 	"github.com/dwarvesf/icy-backend/internal/oracle"
@@ -184,3 +185,7 @@ var _ = Describe("POST /api/v1/swap/generate-signature server-side rate enforcem
 		Expect(parsed).To(HaveKey("data"))
 	})
 })
+
+func (s *stubBaseRPC) FilterSwapEvents(uint64, uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error) {
+	return nil, nil
+}

--- a/internal/handler/swap/swap_info_timeout_test.go
+++ b/internal/handler/swap/swap_info_timeout_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/handler/swap"
 	"github.com/dwarvesf/icy-backend/internal/model"
 	"github.com/dwarvesf/icy-backend/internal/monitoring"
@@ -755,4 +756,8 @@ func getCurrentGoroutineCount() int {
 	// This would need to be implemented using runtime.NumGoroutine()
 	// or similar goroutine tracking mechanism
 	return 0 // Placeholder
+}
+
+func (m *MockBaseRPC) FilterSwapEvents(uint64, uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error) {
+	return nil, nil
 }

--- a/internal/handler/swap/walletauth_authcaller_test.go
+++ b/internal/handler/swap/walletauth_authcaller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 
+	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/model"
 	"github.com/dwarvesf/icy-backend/internal/types/environments"
 	"github.com/dwarvesf/icy-backend/internal/utils/config"
@@ -56,4 +57,8 @@ func newAuthTestHandler(t *testing.T) *handler {
 		appConfig: cfg,
 		baseRPC:   &authMockBaseRPC{balance: "1000000000000000000000"},
 	}
+}
+
+func (m *authMockBaseRPC) FilterSwapEvents(uint64, uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error) {
+	return nil, nil
 }

--- a/internal/monitoring/circuit_breaker.go
+++ b/internal/monitoring/circuit_breaker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/sony/gobreaker"
 
+	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/baserpc"
 	"github.com/dwarvesf/icy-backend/internal/btcrpc"
 	"github.com/dwarvesf/icy-backend/internal/model"
@@ -357,6 +358,20 @@ func (cb *CircuitBreakerBaseRPC) GetTransactionsByAddress(address string, fromTx
 	}
 
 	return result.([]model.OnchainIcyTransaction), nil
+}
+
+func (cb *CircuitBreakerBaseRPC) FilterSwapEvents(startBlock, endBlock uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error) {
+	result, err := cb.circuitBreaker.Execute(func() (interface{}, error) {
+		return cb.executeWithTimeout("filter_swap_events", func() (interface{}, error) {
+			return cb.wrapped.FilterSwapEvents(startBlock, endBlock)
+		})
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result.([]*icyBtcSwap.IcyBtcSwapSwap), nil
 }
 
 func (cb *CircuitBreakerBaseRPC) Swap(icyAmount *model.Web3BigInt, btcAddress string, btcAmount *model.Web3BigInt) (*types.Transaction, error) {

--- a/internal/oracle/oracle_caching_test.go
+++ b/internal/oracle/oracle_caching_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"gorm.io/gorm"
 
+	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/baserpc"
 	"github.com/dwarvesf/icy-backend/internal/btcrpc"
 	"github.com/dwarvesf/icy-backend/internal/model"
@@ -597,3 +598,7 @@ var _ = Describe("Oracle Caching Layer", func() {
 		})
 	})
 })
+
+func (m *MockBaseRPC) FilterSwapEvents(uint64, uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error) {
+	return nil, nil
+}

--- a/internal/server/swap_payout_test.go
+++ b/internal/server/swap_payout_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"gorm.io/gorm"
 
+	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/model"
 	"github.com/dwarvesf/icy-backend/internal/store"
 	"github.com/dwarvesf/icy-backend/internal/telemetry"
@@ -185,4 +186,8 @@ func TestCreateBtcPayout_AbsentDeposit_Rejected(t *testing.T) {
 	if n := countPayouts(t, db, "0xabsent"); n != 0 {
 		t.Fatalf("absent deposit created %d payouts, want 0", n)
 	}
+}
+
+func (m *mockBaseRpc) FilterSwapEvents(uint64, uint64) ([]*icyBtcSwap.IcyBtcSwapSwap, error) {
+	return nil, nil
 }

--- a/internal/telemetry/swap.go
+++ b/internal/telemetry/swap.go
@@ -7,12 +7,10 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"gorm.io/gorm"
 
-	"github.com/dwarvesf/icy-backend/contracts/icyBtcSwap"
 	"github.com/dwarvesf/icy-backend/internal/model"
 	"github.com/dwarvesf/icy-backend/internal/store"
 	"github.com/dwarvesf/icy-backend/internal/utils/webhook"
@@ -62,20 +60,13 @@ func (t *Telemetry) IndexIcySwapTransaction() error {
 		return err
 	}
 
-	// Get contract instance
-	contract, err := icyBtcSwap.NewIcyBtcSwap(t.baseRpc.GetContractAddress(), t.baseRpc.Client())
-	if err != nil {
-		t.logger.Error("[IndexIcySwapTransaction][NewIcyBtcSwap]", map[string]string{
-			"error": err.Error(),
-		})
-		return err
-	}
-
-	// Process blocks in batches
+	// Process blocks in batches. Inclusive spans: end at start+maxRange-1 or
+	// the public RPC's exactly-10,000-block eth_getLogs cap rejects the query
+	// (same off-by-one fixed in baserpc.blockRanges).
 	const maxBlockRange = uint64(10000)
 	var totalProcessed int
 	for currentStart := startBlock; currentStart <= latestBlock; currentStart += maxBlockRange {
-		currentEnd := currentStart + maxBlockRange
+		currentEnd := currentStart + maxBlockRange - 1
 		if currentEnd > latestBlock {
 			currentEnd = latestBlock
 		}
@@ -90,15 +81,11 @@ func (t *Telemetry) IndexIcySwapTransaction() error {
 			})
 		}
 
-		// Create filter options for current block range
-		filterOpts := &bind.FilterOpts{
-			Start:   currentStart,
-			End:     &currentEnd,
-			Context: context.Background(),
-		}
-
-		// Filter Swap events
-		swapEvents, err := contract.FilterSwap(filterOpts)
+		// Filter Swap events through baseRpc, which rebuilds the contract
+		// binding per attempt and rotates endpoints on failure. Never build
+		// a binding from Client() here: it pins the scan to whatever
+		// endpoint the shared client happens to be dialed to.
+		swapEvents, err := t.baseRpc.FilterSwapEvents(currentStart, currentEnd)
 		if err != nil {
 			t.logger.Error("[IndexIcySwapTransaction][FilterSwap]", map[string]string{
 				"error": err.Error(),
@@ -108,11 +95,7 @@ func (t *Telemetry) IndexIcySwapTransaction() error {
 
 		// Process events in batches
 		var txsToStore []*model.OnchainIcySwapTransaction
-		for swapEvents.Next() {
-			event := swapEvents.Event
-			if event == nil {
-				continue
-			}
+		for _, event := range swapEvents {
 
 			// Get transaction to extract from address
 			transaction, isPending, err := t.baseRpc.Client().TransactionByHash(context.Background(), event.Raw.TxHash)
@@ -154,7 +137,6 @@ func (t *Telemetry) IndexIcySwapTransaction() error {
 
 			txsToStore = append(txsToStore, tx)
 		}
-		swapEvents.Close()
 
 		// Store transactions in a single transaction
 		if len(txsToStore) > 0 {


### PR DESCRIPTION
Fixes the live prod failure where icy_swap_transaction_indexing failed every tick: the indexer scanned through a one-shot contract binding pinned to whatever endpoint the shared client last migrated to (stuck on free-tier Alchemy after a boot 429 burst, where getLogs always 400s while eth_call quietly succeeds, so nothing rotated back). New BaseRPC.FilterSwapEvents wraps the scan in withRetry and rebuilds the binding per attempt. Also fixes the second copy of the 10,001-block off-by-one living in telemetry/swap.go (the PR #51 fix only covered baserpc). Full short suite green.