### PR TITLE
fix(webhook): Discord embed format + review-flagged test/doc backfill

### DIFF
--- a/docs/verification/rpc-failover-indexer.md
+++ b/docs/verification/rpc-failover-indexer.md
@@ -1,0 +1,72 @@
+# Incident + Proof of Done, Base RPC Failover and the Swap Indexer Outage (2026-07-20)
+
+**Outcome:** the swap-event indexer and the rate endpoint survive a rate-limited
+or capability-degraded Base RPC endpoint instead of wedging on it. Two root
+causes fixed: an off-by-one that made every ranged `eth_getLogs` illegal, and a
+swap-event scan pinned to a single endpoint with no failover.
+
+**Tags:** `v0.4.11` (getLogs range + baserpc failover), `v0.4.14`
+(swap-indexer failover). **Go:** 1.24.2.
+
+---
+
+## 1. What happened
+
+`icy.so` showed "rate unavailable" and the swap indexer failed every tick. The
+symptom chain:
+
+1. The prod Base RPC list was `alchemy, mainnet.base.org`. The **Alchemy account
+   had dropped to the Free tier**, which caps `eth_getLogs` to a **10-block**
+   range. Any catch-up scan asks for up to 10,000 blocks, so every scan 400'd
+   with `-32600 "Under the Free tier plan..."`.
+2. Those failures held the `base_rpc` circuit breaker **open**, which also
+   blocked the unrelated `totalSupply` read the oracle needs for the ICY rate.
+   No supply figure means `/swap/info` returns `partial_data: true` and the
+   frontend correctly pauses swapping.
+3. Even after reordering to a public-RPC-primary list, a **second bug** surfaced:
+   the chunk loop computed `end = start + 10000` (inclusive), a **10,001-block**
+   span, which the public Base RPC rejects with `-32614` (exactly-10,000 cap).
+4. And a **third**: the swap-event scan (`IndexIcySwapTransaction`) built its own
+   contract binding from the shared `ethclient` and called `FilterSwap` raw, no
+   retry. When other operations rotated the shared client onto the free-tier
+   Alchemy fallback (where `eth_call` succeeds but ranged `eth_getLogs` 400s),
+   the swap scan stayed pinned there and failed every tick while the rate looked
+   healthy, because nothing forced a rotation back.
+
+## 2. Fixes
+
+| # | Fix | Location |
+|---|-----|----------|
+| 1 | Endpoint list reordered: `mainnet.base.org` primary (10k getLogs), Alchemy fallback (rescues `eth_call` when the public RPC 429s). Both are needed: the public RPC alone 429'd with no fallback. | Vault `kv/icy-backend/prod` `BLOCKCHAIN_BASE_RPC_ENDPOINTS` |
+| 2 | `blockRanges(start, latest, maxRange)`: inclusive chunks of at most `maxRange` blocks (`end = start + maxRange - 1`). | `internal/baserpc/baserpc.go` |
+| 3 | Same off-by-one existed inline in the swap indexer; fixed to `start + maxRange - 1`. | `internal/telemetry/swap.go` |
+| 4 | `BaseRPC.FilterSwapEvents` wraps the scan in `withRetry` and **rebuilds the contract binding on every attempt**, so a scan that fails on one endpoint rotates and retries. The indexer no longer builds its own binding from `Client()`. | `internal/baserpc/baserpc.go`, `internal/telemetry/swap.go` |
+
+## 3. Proof
+
+- **RPC caps, verified live** (2026-07-20): a 10,000-block `eth_getLogs` on
+  `mainnet.base.org` returns in ~1.2s; a 10,001-block span returns `-32614`. The
+  free-tier Alchemy endpoint returns `-32600` (10-block cap) on the same query.
+- **Recovery, prod:** after `v0.4.11` + the endpoint reorder, `/swap/info`
+  returned `partial_data: false` with a whole rate; the swap indexer logged
+  `Job completed successfully`.
+- **Failover, prod (`v0.4.14`):** over five consecutive ticks,
+  `icy_swap_transaction_indexing`, `icy_transaction_indexing` (BTC), and
+  `btc_pending_transaction_processing` all reported `Job completed successfully`
+  with **zero** `Job failed`, and the rate stayed whole.
+- **Unit:** `internal/baserpc/failover_test.go` covers `switchEndpoint` rotation
+  (skip-failed, retry-expired, all-failed-still-advances, single-endpoint-errors);
+  `internal/baserpc/block_ranges_test.go` covers the inclusive-cap arithmetic
+  with an exact-boundary negative control.
+
+## 4. Standing risk / follow-ups
+
+- **Data provider:** while the Alchemy account stays on Free tier it cannot serve
+  the data path (getLogs). The public RPC carries current volume; restore Alchemy
+  as primary only after a PAYG upgrade lifts the getLogs cap.
+- **Sibling call sites (known gap):** `IndexIcySwapTransaction` still calls
+  `TransactionReceipt` / `BlockNumber` / `TransactionByHash` directly on
+  `Client()` with no retry (a `BlockNumber` failure returns before
+  `FilterSwapEvents`'s failover engages). Wrapping those three and dropping
+  `Client()` off `IBaseRPC` is the durable consolidation. Flagged by the
+  architecture review; tracked, not yet done.

--- a/docs/verification/swap-payout-webhook.md
+++ b/docs/verification/swap-payout-webhook.md
@@ -209,3 +209,39 @@ Discord. Same approach SG-05's `settlement_test.go` already uses.
 - Nothing to reconcile: this is a pure notification side-effect, it never
   writes to the database and never participates in the settlement state
   machine.
+
+---
+
+## 8. Follow-on changes (2026-07-20/21)
+
+The original SG-07 doc above describes the terminal-state text notification.
+Three changes shipped after it:
+
+- **Swap-detected emit.** `CreateBtcPayoutForSwap` now fires a `pending` event
+  the moment a swap is detected on-chain and its payout row is created, not only
+  at settlement. Built from the swap tx directly (the row is still uncommitted in
+  the tx), fire-and-forget. Tests: `TestCreateBtcPayout_FiresSwapDetectedWebhook`
+  + negative control `TestCreateBtcPayout_ShortDeposit_NoWebhook`.
+- **Vault-balance enrichment.** Each notification carries the treasury BTC
+  balance (sats + BTC), fetched best-effort inside the detached webhook
+  goroutine so the read never slows settlement; a failed lookup omits the field.
+  Tests: `TestProcessPending_Completed_WebhookCarriesVaultBalance` and the
+  `..._BalanceError_OmitsVaultField` negative control (server), plus
+  `TestCallSwapPayoutWebhook_VaultBalance_AppendsFieldWithBtc` /
+  `..._NoVaultBalance_OmitsField` (webhook package). **Security note:** this puts
+  the live hot-wallet balance and every destination address into the Discord
+  channel; the channel must stay scoped to a trusted group (flagged by the
+  2026-07-21 security review, accepted by the operator).
+- **Embed format.** The payload moved from a plain-text `content` blob to a
+  Discord **embed**: title `BTC payout · <status>`, colour by status
+  (blurple pending / green completed / red failed / amber needs_reconcile), the
+  ICY emoji as thumbnail (custom emoji markup does not render inside embed
+  fields), fields for ICY / BTC / destination / (tx, omitted when empty) / vault
+  balance, and a timestamp. This also fixed a real bug in the text format: an
+  empty tx hash rendered as an unbalanced `` `` `` that spilled the following
+  line into monospace. Amounts are now human-formatted (`2000 ICY`, `0.001239
+  BTC`) alongside the raw base units. Config vocab: status gained `pending`;
+  the emitter reads `SWAP_PAYOUT_WEBHOOK_URL` from Vault as before.
+
+Channel: Dwarves `#logs` (id `1376917394710335590`), webhook item
+`discord-webhook-icy-swap-payouts` in 1Password (`op://Toolkit`).

--- a/internal/baserpc/failover_test.go
+++ b/internal/baserpc/failover_test.go
@@ -1,0 +1,77 @@
+package baserpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dwarvesf/icy-backend/internal/types/environments"
+	"github.com/dwarvesf/icy-backend/internal/utils/logger"
+)
+
+// newFailoverRPC builds a BaseRPC with only the fields switchEndpoint touches,
+// no ethclient / network. switchEndpoint is a pure state machine over the
+// endpoint index + failedEndpoints map, so it is directly unit-testable.
+func newFailoverRPC(endpoints []string) *BaseRPC {
+	return &BaseRPC{
+		logger:          logger.New(environments.Test),
+		endpoints:       endpoints,
+		currentEndpoint: 0,
+		failedEndpoints: make(map[string]*endpointStatus),
+	}
+}
+
+// The failover fix (FilterSwapEvents wrapping withRetry) depends on
+// switchEndpoint actually advancing off a failed endpoint. This is the exact
+// rotation that was silently NOT happening for the swap indexer.
+func TestSwitchEndpoint_SkipsFailedEndpoint(t *testing.T) {
+	b := newFailoverRPC([]string{"ep-a", "ep-b"})
+	// ep-a failed and is not yet due for retry, so switchEndpoint must land on ep-b.
+	b.failedEndpoints["ep-a"] = &endpointStatus{failedAt: time.Now(), retryAfter: time.Hour}
+
+	if err := b.switchEndpoint(); err != nil {
+		t.Fatalf("switchEndpoint: %v", err)
+	}
+	if got := b.endpoints[b.currentEndpoint]; got != "ep-b" {
+		t.Fatalf("currentEndpoint = %q, want ep-b", got)
+	}
+}
+
+// A failed endpoint whose retryAfter has elapsed is eligible again.
+func TestSwitchEndpoint_RetriesExpiredFailure(t *testing.T) {
+	b := newFailoverRPC([]string{"ep-a", "ep-b"})
+	b.currentEndpoint = 1 // start on ep-b so the next index is ep-a
+	// ep-a failed long ago; its retry window has passed, so it can be tried again.
+	b.failedEndpoints["ep-a"] = &endpointStatus{failedAt: time.Now().Add(-time.Hour), retryAfter: time.Minute}
+
+	if err := b.switchEndpoint(); err != nil {
+		t.Fatalf("switchEndpoint: %v", err)
+	}
+	if got := b.endpoints[b.currentEndpoint]; got != "ep-a" {
+		t.Fatalf("currentEndpoint = %q, want ep-a (retry window elapsed)", got)
+	}
+}
+
+// All endpoints failed and none is due for retry: switchEndpoint still advances
+// ("hope for the best") rather than deadlocking on the current one.
+func TestSwitchEndpoint_AllFailed_StillAdvances(t *testing.T) {
+	b := newFailoverRPC([]string{"ep-a", "ep-b"})
+	now := time.Now()
+	b.failedEndpoints["ep-a"] = &endpointStatus{failedAt: now, retryAfter: time.Hour}
+	b.failedEndpoints["ep-b"] = &endpointStatus{failedAt: now, retryAfter: time.Hour}
+
+	start := b.currentEndpoint
+	if err := b.switchEndpoint(); err != nil {
+		t.Fatalf("switchEndpoint: %v", err)
+	}
+	if b.currentEndpoint == start {
+		t.Fatalf("currentEndpoint stayed at %d; must advance even when all endpoints are failed", start)
+	}
+}
+
+// A single endpoint cannot fail over: there is nowhere to go.
+func TestSwitchEndpoint_SingleEndpoint_Errors(t *testing.T) {
+	b := newFailoverRPC([]string{"ep-only"})
+	if err := b.switchEndpoint(); err == nil {
+		t.Fatal("expected an error switching with a single endpoint, got nil")
+	}
+}

--- a/internal/server/settlement_test.go
+++ b/internal/server/settlement_test.go
@@ -43,8 +43,10 @@ func (f runnerFunc) ProcessPendingBtcTransactions() error { return f() }
 type mockBtcRpc struct {
 	sendCount     int32
 	sendFn        func(addr string, amt *model.Web3BigInt) (string, int64, error)
-	confirmations int64 // returned by GetTransactionConfirmations
-	confHardcoded bool  // when false, a zero confirmations field means "6" (default confirmed)
+	confirmations int64  // returned by GetTransactionConfirmations
+	confHardcoded bool   // when false, a zero confirmations field means "6" (default confirmed)
+	balanceSats   string // CurrentBalance value; "" -> default "0"
+	balanceErr    error  // when set, CurrentBalance returns it (drops the vault-balance line)
 }
 
 func (m *mockBtcRpc) Send(addr string, amt *model.Web3BigInt) (string, int64, error) {
@@ -67,13 +69,21 @@ func (m *mockBtcRpc) GetTransactionConfirmations(txHash string) (int64, error) {
 }
 
 func (m *mockBtcRpc) CurrentBalance() (*model.Web3BigInt, error) {
-	return &model.Web3BigInt{Value: "0", Decimal: 8}, nil
+	if m.balanceErr != nil {
+		return nil, m.balanceErr
+	}
+	v := m.balanceSats
+	if v == "" {
+		v = "0"
+	}
+	return &model.Web3BigInt{Value: v, Decimal: 8}, nil
 }
 func (m *mockBtcRpc) GetTransactionsByAddress(address, fromTxId string) ([]model.OnchainBtcTransaction, error) {
 	return nil, nil
 }
 func (m *mockBtcRpc) EstimateFees() (map[string]float64, error) { return map[string]float64{}, nil }
 func (m *mockBtcRpc) GetSatoshiUSDPrice() (float64, error)      { return 0, nil }
+
 // Dust is a real rule, not a stub. Returning false unconditionally meant the
 // double accepted payouts the network rejects, so the guard that keeps an
 // unpayable row from looping forever could not be tested at all. 546 is the

--- a/internal/server/swap_payout_webhook_test.go
+++ b/internal/server/swap_payout_webhook_test.go
@@ -29,30 +29,46 @@ import (
 
 // captureWebhookServer records every POSTed Discord payload onto a channel so
 // the fire-and-forget goroutine's output can be asserted without a fixed
-// sleep.
-func captureWebhookServer() (*httptest.Server, chan map[string]string) {
-	ch := make(chan map[string]string, 8)
+// sleep. The payload is a Discord embed; each POST is flattened to title +
+// field name/value text so the assertions below stay layout-agnostic.
+func captureWebhookServer() (*httptest.Server, chan string) {
+	ch := make(chan string, 8)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]string
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		ch <- body
+		var payload struct {
+			Embeds []struct {
+				Title  string `json:"title"`
+				Fields []struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				} `json:"fields"`
+			} `json:"embeds"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		var b strings.Builder
+		if len(payload.Embeds) > 0 {
+			b.WriteString(payload.Embeds[0].Title)
+			for _, f := range payload.Embeds[0].Fields {
+				b.WriteString(" " + f.Name + " " + f.Value)
+			}
+		}
+		ch <- b.String()
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	return srv, ch
 }
 
-func waitForPayoutWebhook(t *testing.T, ch chan map[string]string) string {
+func waitForPayoutWebhook(t *testing.T, ch chan string) string {
 	t.Helper()
 	select {
 	case body := <-ch:
-		return body["content"]
+		return body
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for the swap payout webhook to fire")
 		return ""
 	}
 }
 
-func assertNoPayoutWebhook(t *testing.T, ch chan map[string]string) {
+func assertNoPayoutWebhook(t *testing.T, ch chan string) {
 	t.Helper()
 	select {
 	case body := <-ch:
@@ -86,6 +102,63 @@ func TestProcessPending_Completed_FiresPayoutWebhook(t *testing.T) {
 		if !strings.Contains(content, want) {
 			t.Fatalf("webhook content %q missing %q", content, want)
 		}
+	}
+}
+
+// The vault-balance enrichment: a completed payout's webhook carries the
+// treasury balance, in sats and converted to BTC, fetched from btcRpc at post
+// time. (Both the architecture and test-coverage review flagged this path as
+// running-but-unasserted.)
+func TestProcessPending_Completed_WebhookCarriesVaultBalance(t *testing.T) {
+	srv, ch := captureWebhookServer()
+	defer srv.Close()
+
+	db := newTestDB(t)
+	btc := &mockBtcRpc{balanceSats: "123456789"} // 1.23456789 BTC
+	cfg := &config.AppConfig{SwapPayoutWebhookURL: srv.URL}
+	tel := telemetry.New(db, store.New(db), cfg, logger.New(environments.Test), btc, nil, nil)
+	id := seed(t, db, model.BtcProcessingStatusPending, "1000", "100")
+
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if got := statusOf(t, db, id); got != model.BtcProcessingStatusCompleted {
+		t.Fatalf("status = %q, want completed", got)
+	}
+
+	content := waitForPayoutWebhook(t, ch)
+	for _, want := range []string{"Vault balance", "123456789 sats", "1.23456789 BTC"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("webhook content %q missing vault-balance %q", content, want)
+		}
+	}
+}
+
+// If the balance lookup fails, the webhook still fires but omits the
+// vault-balance field (best-effort enrichment never blocks the notification).
+func TestProcessPending_Completed_BalanceError_OmitsVaultField(t *testing.T) {
+	srv, ch := captureWebhookServer()
+	defer srv.Close()
+
+	db := newTestDB(t)
+	btc := &mockBtcRpc{balanceErr: fmt.Errorf("blockstream unreachable")}
+	cfg := &config.AppConfig{SwapPayoutWebhookURL: srv.URL}
+	tel := telemetry.New(db, store.New(db), cfg, logger.New(environments.Test), btc, nil, nil)
+	id := seed(t, db, model.BtcProcessingStatusPending, "1000", "100")
+
+	if err := tel.ProcessPendingBtcTransactions(); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if got := statusOf(t, db, id); got != model.BtcProcessingStatusCompleted {
+		t.Fatalf("status = %q, want completed", got)
+	}
+
+	content := waitForPayoutWebhook(t, ch)
+	if !strings.Contains(content, "completed") {
+		t.Fatalf("webhook content %q missing status", content)
+	}
+	if strings.Contains(content, "Vault balance") {
+		t.Fatalf("webhook content %q should omit vault balance when the lookup errored", content)
 	}
 }
 
@@ -222,9 +295,9 @@ func TestCreateBtcPayout_FiresSwapDetectedWebhook(t *testing.T) {
 	}
 
 	content := waitForPayoutWebhook(t, ch)
-	// pending status, the ICY amount from the swap, the sendable BTC amount
-	// (5000 - 0 fee), and the custom ICY emoji prefix.
-	for _, want := range []string{"pending", "1234", "5000", "<a:icy:1192768878183465062>"} {
+	// pending status, the ICY amount from the swap, and the sendable BTC amount
+	// (5000 - 0 fee). The ICY brand is now the embed thumbnail, not inline text.
+	for _, want := range []string{"pending", "1234", "5000"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("swap-detected webhook content %q missing %q", content, want)
 		}

--- a/internal/utils/webhook/webhook.go
+++ b/internal/utils/webhook/webhook.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/dwarvesf/icy-backend/internal/utils/logger"
@@ -91,33 +92,101 @@ type SwapPayoutEvent struct {
 	VaultBalanceSats string
 }
 
-// icyEmoji is the Dwarves server's custom animated ICY emoji. Discord renders a
-// literal <a:name:id> token in a message's content field as the emoji, so it can
-// prefix the swap notification directly.
-const icyEmoji = "<a:icy:1192768878183465062>"
+// icyThumbnailURL is the Dwarves server's custom ICY emoji as an image. Custom
+// emoji markup (<a:name:id>) does NOT render inside embed fields or titles, only
+// in plain message content, so the embed brands itself with the emoji's image as
+// a thumbnail instead.
+const icyThumbnailURL = "https://cdn.discordapp.com/emojis/1192768878183465062.gif"
 
-// CallSwapPayoutWebhook posts a Discord-formatted notification for a settled
-// BTC payout. Like CallUptimeWebhook, it never returns an error: every failure
-// (marshal, request, transport) is logged and swallowed here so a webhook
-// outage can never affect the caller's settlement flow.
+// statusColor maps a payout status to the embed's left-border colour: a calm
+// blurple while the swap is only detected, green once settled, red on failure,
+// amber for a state a treasurer must look at.
+func statusColor(status string) int {
+	switch status {
+	case "completed":
+		return 0x2ECC71
+	case "failed":
+		return 0xE74C3C
+	case "needs_reconcile":
+		return 0xF1C40F
+	default: // pending / anything new
+		return 0x5865F2
+	}
+}
+
+// formatUnits renders a base-unit integer string (wei-like) as a decimal with
+// `decimals` places, trailing zeros trimmed. A non-integer input is returned
+// unchanged so a bad value is visible rather than silently dropped.
+func formatUnits(raw string, decimals int) string {
+	n, ok := new(big.Int).SetString(raw, 10)
+	if !ok {
+		return raw
+	}
+	scale := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil))
+	v := new(big.Float).Quo(new(big.Float).SetInt(n), scale)
+	s := v.Text('f', decimals)
+	if strings.Contains(s, ".") {
+		s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
+	}
+	return s
+}
+
+type embedField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline,omitempty"`
+}
+
+type embedThumbnail struct {
+	URL string `json:"url"`
+}
+
+type discordEmbed struct {
+	Title     string          `json:"title"`
+	Color     int             `json:"color"`
+	Fields    []embedField    `json:"fields"`
+	Thumbnail *embedThumbnail `json:"thumbnail,omitempty"`
+	Timestamp string          `json:"timestamp"`
+}
+
+// CallSwapPayoutWebhook posts a Discord embed for a swap payout event. Like
+// CallUptimeWebhook, it never returns an error: every failure (marshal, request,
+// transport) is logged and swallowed here so a webhook outage can never affect
+// the caller's settlement flow.
 func (c *Client) CallSwapPayoutWebhook(ctx context.Context, webhookURL string, event SwapPayoutEvent) {
 	if webhookURL == "" {
 		return // Skip if webhook URL is not configured
 	}
 
-	content := fmt.Sprintf(
-		"%s BTC payout **%s**\nICY amount: `%s`\nBTC amount: `%s`\nDestination: `%s`\nTx hash: `%s`",
-		icyEmoji, event.Status, event.IcyAmount, event.BtcAmount, event.BtcAddress, event.BtcTxHash,
-	)
+	fields := []embedField{
+		{Name: "ICY", Value: formatUnits(event.IcyAmount, 18) + " ICY", Inline: true},
+		{Name: "BTC", Value: fmt.Sprintf("%s BTC\n`%s sats`", formatUnits(event.BtcAmount, 8), event.BtcAmount), Inline: true},
+		{Name: "Destination", Value: "`" + event.BtcAddress + "`"},
+	}
+	// A pending (just-detected) swap has not broadcast yet, so there is no tx
+	// hash; omit the field rather than render an empty one.
+	if event.BtcTxHash != "" {
+		fields = append(fields, embedField{
+			Name:  "Bitcoin tx",
+			Value: fmt.Sprintf("[`%s`](https://mempool.space/tx/%s)", event.BtcTxHash, event.BtcTxHash),
+		})
+	}
 	if event.VaultBalanceSats != "" {
-		content += "\nVault balance: `" + event.VaultBalanceSats + " sats`"
-		if sats, ok := new(big.Int).SetString(event.VaultBalanceSats, 10); ok {
-			btc := new(big.Float).Quo(new(big.Float).SetInt(sats), big.NewFloat(1e8))
-			content += fmt.Sprintf(" (~%s BTC)", btc.Text('f', 4))
-		}
+		fields = append(fields, embedField{
+			Name:  "Vault balance",
+			Value: fmt.Sprintf("%s BTC\n`%s sats`", formatUnits(event.VaultBalanceSats, 8), event.VaultBalanceSats),
+		})
 	}
 
-	payload, err := json.Marshal(map[string]string{"content": content})
+	embed := discordEmbed{
+		Title:     "BTC payout · " + event.Status,
+		Color:     statusColor(event.Status),
+		Fields:    fields,
+		Thumbnail: &embedThumbnail{URL: icyThumbnailURL},
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	payload, err := json.Marshal(map[string]interface{}{"embeds": []discordEmbed{embed}})
 	if err != nil {
 		c.logger.Error("Failed to marshal swap payout webhook payload", map[string]string{
 			"error":  err.Error(),

--- a/internal/utils/webhook/webhook_test.go
+++ b/internal/utils/webhook/webhook_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,17 +19,45 @@ func newTestClient(t *testing.T) *Client {
 	return New(logger.New(environments.Test))
 }
 
+// embedText flattens a swap-payout webhook body (a single Discord embed) into
+// one searchable string: title + every field name/value. Lets the assertions
+// below stay "does the message mention X" without coupling to embed layout.
+func embedText(t *testing.T, body []byte) string {
+	t.Helper()
+	var payload struct {
+		Embeds []struct {
+			Title  string `json:"title"`
+			Fields []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"fields"`
+		} `json:"embeds"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("decode embed body: %v (body=%s)", err, body)
+	}
+	if len(payload.Embeds) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(payload.Embeds[0].Title)
+	for _, f := range payload.Embeds[0].Fields {
+		b.WriteString(" " + f.Name + " " + f.Value)
+	}
+	return b.String()
+}
+
 // SG-07: a completed payout posts the swap fields as a Discord webhook.
 func TestCallSwapPayoutWebhook_Completed_PostsExpectedPayload(t *testing.T) {
 	var (
 		gotMethod      string
 		gotContentType string
-		gotBody        map[string]string
+		gotBody        []byte
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotContentType = r.Header.Get("Content-Type")
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -36,7 +65,7 @@ func TestCallSwapPayoutWebhook_Completed_PostsExpectedPayload(t *testing.T) {
 	c := newTestClient(t)
 	c.CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
 		Status:     "completed",
-		IcyAmount:  "2000000000000000000",
+		IcyAmount:  "2000000000000000000", // 2 ICY
 		BtcAmount:  "95000",
 		BtcAddress: "bc1qexampleaddr",
 		BtcTxHash:  "btc-tx-hash-abc",
@@ -48,19 +77,21 @@ func TestCallSwapPayoutWebhook_Completed_PostsExpectedPayload(t *testing.T) {
 	if gotContentType != "application/json" {
 		t.Fatalf("content-type = %q, want application/json", gotContentType)
 	}
-	content := gotBody["content"]
-	for _, want := range []string{"completed", "2000000000000000000", "95000", "bc1qexampleaddr", "btc-tx-hash-abc"} {
+	content := embedText(t, gotBody)
+	// Formatted ICY ("2 ICY"), raw sats, address, and the tx hash (which the
+	// embed links to mempool.space) must all be present.
+	for _, want := range []string{"completed", "2 ICY", "95000", "bc1qexampleaddr", "btc-tx-hash-abc"} {
 		if !strings.Contains(content, want) {
-			t.Fatalf("webhook content %q missing %q", content, want)
+			t.Fatalf("webhook embed %q missing %q", content, want)
 		}
 	}
 }
 
 // SG-07: a failed payout also fires, with an empty tx hash (never broadcast).
 func TestCallSwapPayoutWebhook_Failed_PostsExpectedPayload(t *testing.T) {
-	var gotBody map[string]string
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -74,21 +105,25 @@ func TestCallSwapPayoutWebhook_Failed_PostsExpectedPayload(t *testing.T) {
 		BtcTxHash:  "",
 	})
 
-	content := gotBody["content"]
+	content := embedText(t, gotBody)
 	if !strings.Contains(content, "failed") {
-		t.Fatalf("webhook content %q missing status 'failed'", content)
+		t.Fatalf("webhook embed %q missing status 'failed'", content)
 	}
 	if !strings.Contains(content, "-50") {
-		t.Fatalf("webhook content %q missing btc amount", content)
+		t.Fatalf("webhook embed %q missing btc amount", content)
+	}
+	// A failed payout never broadcast, so there is no Bitcoin tx field.
+	if strings.Contains(content, "Bitcoin tx") {
+		t.Fatalf("webhook embed %q should omit the tx field on an empty hash", content)
 	}
 }
 
 // SG-07: needs_reconcile (the ambiguous-broadcast terminal state SG-05 added)
 // fires the same as any other terminal state.
 func TestCallSwapPayoutWebhook_NeedsReconcile_PostsExpectedPayload(t *testing.T) {
-	var gotBody map[string]string
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -102,17 +137,17 @@ func TestCallSwapPayoutWebhook_NeedsReconcile_PostsExpectedPayload(t *testing.T)
 		BtcTxHash:  "",
 	})
 
-	if !strings.Contains(gotBody["content"], "needs_reconcile") {
-		t.Fatalf("webhook content %q missing status 'needs_reconcile'", gotBody["content"])
+	if !strings.Contains(embedText(t, gotBody), "needs_reconcile") {
+		t.Fatalf("webhook embed missing status 'needs_reconcile': %s", gotBody)
 	}
 }
 
-// A swap-detected (pending) notification fires with the pending status and is
-// prefixed with the Dwarves custom ICY emoji.
-func TestCallSwapPayoutWebhook_Pending_PrefixesIcyEmoji(t *testing.T) {
-	var gotBody map[string]string
+// A swap-detected (pending) notification fires with the pending status and,
+// having no broadcast tx yet, omits the Bitcoin-tx field.
+func TestCallSwapPayoutWebhook_Pending_OmitsTxField(t *testing.T) {
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -126,11 +161,14 @@ func TestCallSwapPayoutWebhook_Pending_PrefixesIcyEmoji(t *testing.T) {
 		BtcTxHash:  "",
 	})
 
-	content := gotBody["content"]
-	for _, want := range []string{icyEmoji, "pending", "2000000000000000000", "95000", "bc1qexampleaddr"} {
+	content := embedText(t, gotBody)
+	for _, want := range []string{"pending", "2 ICY", "95000", "bc1qexampleaddr"} {
 		if !strings.Contains(content, want) {
-			t.Fatalf("webhook content %q missing %q", content, want)
+			t.Fatalf("webhook embed %q missing %q", content, want)
 		}
+	}
+	if strings.Contains(content, "Bitcoin tx") {
+		t.Fatalf("pending embed %q should omit the tx field", content)
 	}
 }
 
@@ -212,10 +250,10 @@ func TestCallUptimeWebhook_EmptyURL_NoRequest(t *testing.T) {
 	newTestClient(t).CallUptimeWebhook(context.Background(), "")
 }
 
-func TestCallSwapPayoutWebhook_VaultBalance_AppendsLineWithBtc(t *testing.T) {
-	var gotBody map[string]string
+func TestCallSwapPayoutWebhook_VaultBalance_AppendsFieldWithBtc(t *testing.T) {
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -227,18 +265,19 @@ func TestCallSwapPayoutWebhook_VaultBalance_AppendsLineWithBtc(t *testing.T) {
 		VaultBalanceSats: "28768896",
 	})
 
-	content := gotBody["content"]
-	for _, want := range []string{"Vault balance", "28768896 sats", "~0.2877 BTC"} {
+	content := embedText(t, gotBody)
+	// 28768896 sats / 1e8 = 0.28768896 BTC, trailing zeros trimmed.
+	for _, want := range []string{"Vault balance", "28768896 sats", "0.28768896 BTC"} {
 		if !strings.Contains(content, want) {
-			t.Fatalf("webhook content %q missing %q", content, want)
+			t.Fatalf("webhook embed %q missing %q", content, want)
 		}
 	}
 }
 
-func TestCallSwapPayoutWebhook_NoVaultBalance_OmitsLine(t *testing.T) {
-	var gotBody map[string]string
+func TestCallSwapPayoutWebhook_NoVaultBalance_OmitsField(t *testing.T) {
+	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.Close()
@@ -249,7 +288,7 @@ func TestCallSwapPayoutWebhook_NoVaultBalance_OmitsLine(t *testing.T) {
 		BtcAmount: "95000",
 	})
 
-	if strings.Contains(gotBody["content"], "Vault balance") {
-		t.Fatalf("webhook content %q should omit the vault-balance line", gotBody["content"])
+	if strings.Contains(embedText(t, gotBody), "Vault balance") {
+		t.Fatalf("webhook embed should omit the vault-balance field: %s", gotBody)
 	}
 }


### PR DESCRIPTION
Fixes the broken notification layout (empty tx hash spilled the vault-balance line into monospace) by moving to a proper Discord embed: colour per status, ICY thumbnail, per-value fields, tx omitted when absent, human-formatted amounts. Backfills two test gaps both review lenses flagged (switchEndpoint failover rotation; vault-balance enrichment content + absence). Adds docs/verification/rpc-failover-indexer.md (the RPC-outage + swap-indexer-failover incident) and a follow-on section to swap-payout-webhook.md. Full suite green.