### PR TITLE
feat(webhook): compact completed-only swap embed

### DIFF
--- a/internal/server/swap_payout_webhook_test.go
+++ b/internal/server/swap_payout_webhook_test.go
@@ -36,8 +36,9 @@ func captureWebhookServer() (*httptest.Server, chan string) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload struct {
 			Embeds []struct {
-				Title  string `json:"title"`
-				Fields []struct {
+				Title       string `json:"title"`
+				Description string `json:"description"`
+				Fields      []struct {
 					Name  string `json:"name"`
 					Value string `json:"value"`
 				} `json:"fields"`
@@ -46,7 +47,7 @@ func captureWebhookServer() (*httptest.Server, chan string) {
 		_ = json.NewDecoder(r.Body).Decode(&payload)
 		var b strings.Builder
 		if len(payload.Embeds) > 0 {
-			b.WriteString(payload.Embeds[0].Title)
+			b.WriteString(payload.Embeds[0].Title + " " + payload.Embeds[0].Description)
 			for _, f := range payload.Embeds[0].Fields {
 				b.WriteString(" " + f.Name + " " + f.Value)
 			}
@@ -98,7 +99,8 @@ func TestProcessPending_Completed_FiresPayoutWebhook(t *testing.T) {
 	}
 
 	content := waitForPayoutWebhook(t, ch)
-	for _, want := range []string{"completed", "900", "bc1qexampleaddr", "btc-tx-hash"} {
+	// 900 sats sendable -> "0.000009" BTC; address + tx in the description.
+	for _, want := range []string{"Swap completed", "0.000009", "bc1qexampleaddr", "btc-tx-hash"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("webhook content %q missing %q", content, want)
 		}
@@ -127,7 +129,7 @@ func TestProcessPending_Completed_WebhookCarriesVaultBalance(t *testing.T) {
 	}
 
 	content := waitForPayoutWebhook(t, ch)
-	for _, want := range []string{"Vault balance", "123456789 sats", "1.23456789 BTC"} {
+	for _, want := range []string{"Vault", "1.23456789 ₿"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("webhook content %q missing vault-balance %q", content, want)
 		}
@@ -154,17 +156,17 @@ func TestProcessPending_Completed_BalanceError_OmitsVaultField(t *testing.T) {
 	}
 
 	content := waitForPayoutWebhook(t, ch)
-	if !strings.Contains(content, "completed") {
+	if !strings.Contains(content, "Swap completed") {
 		t.Fatalf("webhook content %q missing status", content)
 	}
-	if strings.Contains(content, "Vault balance") {
+	if strings.Contains(content, "Vault") {
 		t.Fatalf("webhook content %q should omit vault balance when the lookup errored", content)
 	}
 }
 
-// Failed payout (unpayable row: empty BTC address): fires with status=failed
-// and no tx hash (nothing was ever broadcast).
-func TestProcessPending_UnpayableRow_FiresFailedWebhook(t *testing.T) {
+// Completed-only (operator decision 2026-07-21): a FAILED payout (unpayable
+// row, empty BTC address) settles but fires NO webhook.
+func TestProcessPending_UnpayableRow_NoWebhook(t *testing.T) {
 	srv, ch := captureWebhookServer()
 	defer srv.Close()
 
@@ -189,44 +191,12 @@ func TestProcessPending_UnpayableRow_FiresFailedWebhook(t *testing.T) {
 	if got := statusOf(t, db, row.ID); got != model.BtcProcessingStatusFailed {
 		t.Fatalf("status = %q, want failed", got)
 	}
-
-	content := waitForPayoutWebhook(t, ch)
-	if !strings.Contains(content, "failed") {
-		t.Fatalf("webhook content %q missing status failed", content)
-	}
-	if strings.Contains(content, "btc-tx-hash") {
-		t.Fatalf("webhook content %q unexpectedly carries a tx hash for a never-broadcast payout", content)
-	}
+	assertNoPayoutWebhook(t, ch)
 }
 
-// Failed payout (negative-amount guard): fires with status=failed and the
-// negative computed amount, still no tx hash.
-func TestProcessPending_NegativeAmount_FiresFailedWebhook(t *testing.T) {
-	srv, ch := captureWebhookServer()
-	defer srv.Close()
-
-	db := newTestDB(t)
-	btc := &mockBtcRpc{}
-	cfg := &config.AppConfig{SwapPayoutWebhookURL: srv.URL}
-	tel := telemetry.New(db, store.New(db), cfg, logger.New(environments.Test), btc, nil, nil)
-	id := seed(t, db, model.BtcProcessingStatusPending, "50", "100") // 50 - 100 = -50
-
-	if err := tel.ProcessPendingBtcTransactions(); err != nil {
-		t.Fatalf("process: %v", err)
-	}
-	if got := statusOf(t, db, id); got != model.BtcProcessingStatusFailed {
-		t.Fatalf("status = %q, want failed", got)
-	}
-
-	content := waitForPayoutWebhook(t, ch)
-	if !strings.Contains(content, "failed") || !strings.Contains(content, "-50") {
-		t.Fatalf("webhook content %q missing status failed / amount -50", content)
-	}
-}
-
-// needs_reconcile (the ambiguous-broadcast terminal state SG-05 added): fires
-// with status=needs_reconcile, same as any other terminal transition.
-func TestProcessPending_AmbiguousError_FiresNeedsReconcileWebhook(t *testing.T) {
+// Completed-only: a needs_reconcile terminal state (ambiguous broadcast) settles
+// but fires NO webhook.
+func TestProcessPending_AmbiguousError_NoWebhook(t *testing.T) {
 	srv, ch := captureWebhookServer()
 	defer srv.Close()
 
@@ -244,11 +214,7 @@ func TestProcessPending_AmbiguousError_FiresNeedsReconcileWebhook(t *testing.T) 
 	if got := statusOf(t, db, id); got != model.BtcProcessingStatusNeedsReconcile {
 		t.Fatalf("status = %q, want needs_reconcile", got)
 	}
-
-	content := waitForPayoutWebhook(t, ch)
-	if !strings.Contains(content, "needs_reconcile") {
-		t.Fatalf("webhook content %q missing status needs_reconcile", content)
-	}
+	assertNoPayoutWebhook(t, ch)
 }
 
 // Non-terminal release-to-pending (NotBroadcast error) must NOT fire a
@@ -275,10 +241,10 @@ func TestProcessPending_ReleasedToPending_NoWebhook(t *testing.T) {
 	assertNoPayoutWebhook(t, ch)
 }
 
-// Swap detected: creating the payout row for a verified swap fires a "pending"
-// notification carrying the ICY amount, so the channel hears about a swap when
-// it is detected on-chain, not only when the payout settles.
-func TestCreateBtcPayout_FiresSwapDetectedWebhook(t *testing.T) {
+// Completed-only (operator decision 2026-07-21): detecting a swap and creating
+// its pending payout row fires NO webhook; only the later completed settlement
+// does. The swap-detected "pending" emit was removed.
+func TestCreateBtcPayout_Detected_NoWebhook(t *testing.T) {
 	srv, ch := captureWebhookServer()
 	defer srv.Close()
 
@@ -294,14 +260,7 @@ func TestCreateBtcPayout_FiresSwapDetectedWebhook(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	content := waitForPayoutWebhook(t, ch)
-	// pending status, the ICY amount from the swap, and the sendable BTC amount
-	// (5000 - 0 fee). The ICY brand is now the embed thumbnail, not inline text.
-	for _, want := range []string{"pending", "1234", "5000"} {
-		if !strings.Contains(content, want) {
-			t.Fatalf("swap-detected webhook content %q missing %q", content, want)
-		}
-	}
+	assertNoPayoutWebhook(t, ch)
 }
 
 // Negative control: a REJECTED swap (short ICY deposit) creates no payout row,

--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -165,6 +165,13 @@ func (t *Telemetry) fireSwapPayoutWebhook(client *webhook.Client, event webhook.
 	if webhookURL == "" {
 		return
 	}
+	// Only a completed swap is worth a notification (operator decision
+	// 2026-07-21). Failed / needs_reconcile / pending are dropped here rather
+	// than at each call site, so re-enabling an anomaly alert later is a
+	// one-line change in one place.
+	if event.Status != string(model.BtcProcessingStatusCompleted) {
+		return
+	}
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), swapPayoutWebhookTimeout)
 		defer cancel()

--- a/internal/telemetry/btc.go
+++ b/internal/telemetry/btc.go
@@ -136,7 +136,7 @@ func (t *Telemetry) emitSwapPayoutWebhook(client *webhook.Client, pendingTx mode
 	// failure (row not found, or a test DB without the table) must never block
 	// the notification or the settlement transition, so it just logs and
 	// leaves the field empty.
-	icyAmount := ""
+	icyAmount, fromAddress := "", ""
 	if swapTx, err := t.store.OnchainIcySwapTransaction.GetByTransactionHash(t.db, pendingTx.SwapTransactionHash); err != nil {
 		t.logger.Error("[ProcessPendingBtcTransactions][SwapPayoutWebhook][GetByTransactionHash]", map[string]string{
 			"error": err.Error(),
@@ -144,14 +144,16 @@ func (t *Telemetry) emitSwapPayoutWebhook(client *webhook.Client, pendingTx mode
 		})
 	} else {
 		icyAmount = swapTx.IcyAmount
+		fromAddress = swapTx.FromAddress
 	}
 
 	t.fireSwapPayoutWebhook(client, webhook.SwapPayoutEvent{
-		Status:     string(status),
-		IcyAmount:  icyAmount,
-		BtcAmount:  btcAmount,
-		BtcAddress: pendingTx.BTCAddress,
-		BtcTxHash:  btcTxHash,
+		Status:      string(status),
+		IcyAmount:   icyAmount,
+		BtcAmount:   btcAmount,
+		FromAddress: fromAddress,
+		BtcAddress:  pendingTx.BTCAddress,
+		BtcTxHash:   btcTxHash,
 	})
 }
 

--- a/internal/telemetry/swap.go
+++ b/internal/telemetry/swap.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/dwarvesf/icy-backend/internal/model"
 	"github.com/dwarvesf/icy-backend/internal/store"
-	"github.com/dwarvesf/icy-backend/internal/utils/webhook"
 )
 
 // IndexIcySwapTransaction fetches and stores Swap events from the contract
@@ -350,20 +349,6 @@ func (t *Telemetry) CreateBtcPayoutForSwap(tx *gorm.DB, swapTx *model.OnchainIcy
 		})
 		return err
 	}
-
-	// Notify that a swap was DETECTED on-chain, so the channel hears about it when
-	// the payout is created (status "pending"), not only when it settles. Built
-	// from swapTx directly (its IcyAmount/BtcAddress and the just-computed sendable
-	// total) rather than a DB lookup, because the swap row is still uncommitted in
-	// this tx. Fire-and-forget: it never blocks or fails the payout creation, and
-	// no BtcTxHash exists yet (nothing broadcast).
-	t.fireSwapPayoutWebhook(webhook.New(t.logger), webhook.SwapPayoutEvent{
-		Status:     string(model.BtcProcessingStatusPending),
-		IcyAmount:  swapTx.IcyAmount,
-		BtcAmount:  totalBig.String(),
-		BtcAddress: swapTx.BtcAddress,
-		BtcTxHash:  "",
-	})
 	return nil
 }
 

--- a/internal/utils/webhook/webhook.go
+++ b/internal/utils/webhook/webhook.go
@@ -80,11 +80,12 @@ func (c *Client) CallUptimeWebhook(ctx context.Context, webhookURL string) {
 // exists so a swap, drain, or anomaly is visible somewhere other than the
 // in-page browser toast.
 type SwapPayoutEvent struct {
-	Status     string // pending | completed | failed | needs_reconcile
-	IcyAmount  string
-	BtcAmount  string
-	BtcAddress string
-	BtcTxHash  string
+	Status      string // pending | completed | failed | needs_reconcile
+	IcyAmount   string
+	BtcAmount   string
+	FromAddress string // the EVM wallet that made the swap ("who")
+	BtcAddress  string
+	BtcTxHash   string
 	// VaultBalanceSats is the treasury BTC balance in satoshi at post time,
 	// fetched best-effort by the emitter. Empty = the lookup failed or was
 	// skipped; the message simply omits the line rather than showing a stale
@@ -103,8 +104,9 @@ const btcEmoji = "🟠"
 const completedColor = 0xF7931A
 
 // formatUnits renders a base-unit integer string (wei-like) as a decimal with
-// `decimals` places, trailing zeros trimmed. A non-integer input is returned
-// unchanged so a bad value is visible rather than silently dropped.
+// `decimals` places, trailing zeros trimmed and thousands separators on the
+// integer part (2000000000000000000, 18 -> "2,000"). A non-integer input is
+// returned unchanged so a bad value is visible rather than silently dropped.
 func formatUnits(raw string, decimals int) string {
 	n, ok := new(big.Int).SetString(raw, 10)
 	if !ok {
@@ -116,7 +118,37 @@ func formatUnits(raw string, decimals int) string {
 	if strings.Contains(s, ".") {
 		s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
 	}
-	return s
+	intPart, frac, hasFrac := strings.Cut(s, ".")
+	intPart = groupThousands(intPart)
+	if hasFrac {
+		return intPart + "." + frac
+	}
+	return intPart
+}
+
+// groupThousands inserts commas into a plain integer string (a leading "-" is
+// preserved). "1234567" -> "1,234,567".
+func groupThousands(intPart string) string {
+	neg := strings.HasPrefix(intPart, "-")
+	digits := strings.TrimPrefix(intPart, "-")
+	n := len(digits)
+	if n <= 3 {
+		return intPart
+	}
+	var b strings.Builder
+	if neg {
+		b.WriteByte('-')
+	}
+	lead := n % 3
+	if lead == 0 {
+		lead = 3
+	}
+	b.WriteString(digits[:lead])
+	for i := lead; i < n; i += 3 {
+		b.WriteByte(',')
+		b.WriteString(digits[i : i+3])
+	}
+	return b.String()
 }
 
 type embedField struct {
@@ -161,7 +193,13 @@ func (c *Client) CallSwapPayoutWebhook(ctx context.Context, webhookURL string, e
 		fields = append(fields, embedField{Name: "Vault", Value: formatUnits(event.VaultBalanceSats, 8) + " ₿", Inline: true})
 	}
 
-	desc := "`" + truncAddr(event.BtcAddress) + "`"
+	// Who swapped and where it went: the EVM wallet -> the BTC destination,
+	// both truncated, with the mempool link for the payout tx.
+	desc := ""
+	if event.FromAddress != "" {
+		desc = fmt.Sprintf("[`%s`](https://basescan.org/address/%s) → ", truncAddr(event.FromAddress), event.FromAddress)
+	}
+	desc += "`" + truncAddr(event.BtcAddress) + "`"
 	if event.BtcTxHash != "" {
 		desc += fmt.Sprintf(" · [view tx ↗](https://mempool.space/tx/%s)", event.BtcTxHash)
 	}

--- a/internal/utils/webhook/webhook.go
+++ b/internal/utils/webhook/webhook.go
@@ -92,27 +92,15 @@ type SwapPayoutEvent struct {
 	VaultBalanceSats string
 }
 
-// icyThumbnailURL is the Dwarves server's custom ICY emoji as an image. Custom
-// emoji markup (<a:name:id>) does NOT render inside embed fields or titles, only
-// in plain message content, so the embed brands itself with the emoji's image as
-// a thumbnail instead.
-const icyThumbnailURL = "https://cdn.discordapp.com/emojis/1192768878183465062.gif"
+// btcEmoji prefixes the embed title: the orange circle, the closest unicode to
+// the Bitcoin coin and a match for the orange border. Unicode (unlike a custom
+// <:name:id> emoji) DOES render in an embed title, so no thumbnail is needed.
+const btcEmoji = "🟠"
 
-// statusColor maps a payout status to the embed's left-border colour: a calm
-// blurple while the swap is only detected, green once settled, red on failure,
-// amber for a state a treasurer must look at.
-func statusColor(status string) int {
-	switch status {
-	case "completed":
-		return 0x2ECC71
-	case "failed":
-		return 0xE74C3C
-	case "needs_reconcile":
-		return 0xF1C40F
-	default: // pending / anything new
-		return 0x5865F2
-	}
-}
+// completedColor is the embed's left-border colour: Bitcoin orange. Only
+// completed swaps are notified (see Telemetry.fireSwapPayoutWebhook), so a
+// single colour suffices.
+const completedColor = 0xF7931A
 
 // formatUnits renders a base-unit integer string (wei-like) as a decimal with
 // `decimals` places, trailing zeros trimmed. A non-integer input is returned
@@ -137,19 +125,24 @@ type embedField struct {
 	Inline bool   `json:"inline,omitempty"`
 }
 
-type embedThumbnail struct {
-	URL string `json:"url"`
-}
-
 type discordEmbed struct {
-	Title     string          `json:"title"`
-	Color     int             `json:"color"`
-	Fields    []embedField    `json:"fields"`
-	Thumbnail *embedThumbnail `json:"thumbnail,omitempty"`
-	Timestamp string          `json:"timestamp"`
+	Title       string       `json:"title"`
+	Description string       `json:"description,omitempty"`
+	Color       int          `json:"color"`
+	Fields      []embedField `json:"fields"`
+	Timestamp   string       `json:"timestamp"`
 }
 
-// CallSwapPayoutWebhook posts a Discord embed for a swap payout event. Like
+// truncAddr shortens a BTC address to head…tail so the description stays on one
+// line; the full address is one click away via the mempool link.
+func truncAddr(a string) string {
+	if len(a) <= 16 {
+		return a
+	}
+	return a[:8] + "…" + a[len(a)-6:]
+}
+
+// CallSwapPayoutWebhook posts a compact Discord embed for a completed swap. Like
 // CallUptimeWebhook, it never returns an error: every failure (marshal, request,
 // transport) is logged and swallowed here so a webhook outage can never affect
 // the caller's settlement flow.
@@ -158,32 +151,27 @@ func (c *Client) CallSwapPayoutWebhook(ctx context.Context, webhookURL string, e
 		return // Skip if webhook URL is not configured
 	}
 
+	// Three inline fields pack into one row (the amounts + treasury); the
+	// destination and tx link sit in the description as a single compact line.
 	fields := []embedField{
-		{Name: "ICY", Value: formatUnits(event.IcyAmount, 18) + " ICY", Inline: true},
-		{Name: "BTC", Value: fmt.Sprintf("%s BTC\n`%s sats`", formatUnits(event.BtcAmount, 8), event.BtcAmount), Inline: true},
-		{Name: "Destination", Value: "`" + event.BtcAddress + "`"},
-	}
-	// A pending (just-detected) swap has not broadcast yet, so there is no tx
-	// hash; omit the field rather than render an empty one.
-	if event.BtcTxHash != "" {
-		fields = append(fields, embedField{
-			Name:  "Bitcoin tx",
-			Value: fmt.Sprintf("[`%s`](https://mempool.space/tx/%s)", event.BtcTxHash, event.BtcTxHash),
-		})
+		{Name: "ICY", Value: formatUnits(event.IcyAmount, 18), Inline: true},
+		{Name: "BTC", Value: formatUnits(event.BtcAmount, 8), Inline: true},
 	}
 	if event.VaultBalanceSats != "" {
-		fields = append(fields, embedField{
-			Name:  "Vault balance",
-			Value: fmt.Sprintf("%s BTC\n`%s sats`", formatUnits(event.VaultBalanceSats, 8), event.VaultBalanceSats),
-		})
+		fields = append(fields, embedField{Name: "Vault", Value: formatUnits(event.VaultBalanceSats, 8) + " ₿", Inline: true})
+	}
+
+	desc := "`" + truncAddr(event.BtcAddress) + "`"
+	if event.BtcTxHash != "" {
+		desc += fmt.Sprintf(" · [view tx ↗](https://mempool.space/tx/%s)", event.BtcTxHash)
 	}
 
 	embed := discordEmbed{
-		Title:     "BTC payout · " + event.Status,
-		Color:     statusColor(event.Status),
-		Fields:    fields,
-		Thumbnail: &embedThumbnail{URL: icyThumbnailURL},
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Title:       btcEmoji + " Swap completed",
+		Description: desc,
+		Color:       completedColor,
+		Fields:      fields,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
 	}
 
 	payload, err := json.Marshal(map[string]interface{}{"embeds": []discordEmbed{embed}})

--- a/internal/utils/webhook/webhook_test.go
+++ b/internal/utils/webhook/webhook_test.go
@@ -26,8 +26,9 @@ func embedText(t *testing.T, body []byte) string {
 	t.Helper()
 	var payload struct {
 		Embeds []struct {
-			Title  string `json:"title"`
-			Fields []struct {
+			Title       string `json:"title"`
+			Description string `json:"description"`
+			Fields      []struct {
 				Name  string `json:"name"`
 				Value string `json:"value"`
 			} `json:"fields"`
@@ -40,7 +41,7 @@ func embedText(t *testing.T, body []byte) string {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString(payload.Embeds[0].Title)
+	b.WriteString(payload.Embeds[0].Title + " " + payload.Embeds[0].Description)
 	for _, f := range payload.Embeds[0].Fields {
 		b.WriteString(" " + f.Name + " " + f.Value)
 	}
@@ -78,17 +79,19 @@ func TestCallSwapPayoutWebhook_Completed_PostsExpectedPayload(t *testing.T) {
 		t.Fatalf("content-type = %q, want application/json", gotContentType)
 	}
 	content := embedText(t, gotBody)
-	// Formatted ICY ("2 ICY"), raw sats, address, and the tx hash (which the
-	// embed links to mempool.space) must all be present.
-	for _, want := range []string{"completed", "2 ICY", "95000", "bc1qexampleaddr", "btc-tx-hash-abc"} {
+	// Compact: "Swap completed" title, formatted ICY (2e18 -> "2") and BTC
+	// (95000 sats -> "0.00095"), the destination, and the tx in the mempool link.
+	for _, want := range []string{"Swap completed", "2", "0.00095", "bc1qexampleaddr", "btc-tx-hash-abc"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("webhook embed %q missing %q", content, want)
 		}
 	}
 }
 
-// SG-07: a failed payout also fires, with an empty tx hash (never broadcast).
-func TestCallSwapPayoutWebhook_Failed_PostsExpectedPayload(t *testing.T) {
+// With no broadcast tx yet (an empty hash), the description carries no mempool
+// link. The renderer is only ever handed completed events (the status gate lives
+// in Telemetry.fireSwapPayoutWebhook), so it does not branch on status.
+func TestCallSwapPayoutWebhook_EmptyTxHash_OmitsMempoolLink(t *testing.T) {
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotBody, _ = io.ReadAll(r.Body)
@@ -98,63 +101,7 @@ func TestCallSwapPayoutWebhook_Failed_PostsExpectedPayload(t *testing.T) {
 
 	c := newTestClient(t)
 	c.CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
-		Status:     "failed",
-		IcyAmount:  "1000000000000000000",
-		BtcAmount:  "-50",
-		BtcAddress: "bc1qexampleaddr",
-		BtcTxHash:  "",
-	})
-
-	content := embedText(t, gotBody)
-	if !strings.Contains(content, "failed") {
-		t.Fatalf("webhook embed %q missing status 'failed'", content)
-	}
-	if !strings.Contains(content, "-50") {
-		t.Fatalf("webhook embed %q missing btc amount", content)
-	}
-	// A failed payout never broadcast, so there is no Bitcoin tx field.
-	if strings.Contains(content, "Bitcoin tx") {
-		t.Fatalf("webhook embed %q should omit the tx field on an empty hash", content)
-	}
-}
-
-// SG-07: needs_reconcile (the ambiguous-broadcast terminal state SG-05 added)
-// fires the same as any other terminal state.
-func TestCallSwapPayoutWebhook_NeedsReconcile_PostsExpectedPayload(t *testing.T) {
-	var gotBody []byte
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t)
-	c.CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
-		Status:     "needs_reconcile",
-		IcyAmount:  "3000000000000000000",
-		BtcAmount:  "120000",
-		BtcAddress: "bc1qexampleaddr",
-		BtcTxHash:  "",
-	})
-
-	if !strings.Contains(embedText(t, gotBody), "needs_reconcile") {
-		t.Fatalf("webhook embed missing status 'needs_reconcile': %s", gotBody)
-	}
-}
-
-// A swap-detected (pending) notification fires with the pending status and,
-// having no broadcast tx yet, omits the Bitcoin-tx field.
-func TestCallSwapPayoutWebhook_Pending_OmitsTxField(t *testing.T) {
-	var gotBody []byte
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer srv.Close()
-
-	c := newTestClient(t)
-	c.CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
-		Status:     "pending",
+		Status:     "completed",
 		IcyAmount:  "2000000000000000000",
 		BtcAmount:  "95000",
 		BtcAddress: "bc1qexampleaddr",
@@ -162,13 +109,13 @@ func TestCallSwapPayoutWebhook_Pending_OmitsTxField(t *testing.T) {
 	})
 
 	content := embedText(t, gotBody)
-	for _, want := range []string{"pending", "2 ICY", "95000", "bc1qexampleaddr"} {
+	for _, want := range []string{"Swap completed", "bc1qexampleaddr"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("webhook embed %q missing %q", content, want)
 		}
 	}
-	if strings.Contains(content, "Bitcoin tx") {
-		t.Fatalf("pending embed %q should omit the tx field", content)
+	if strings.Contains(content, "mempool.space") {
+		t.Fatalf("embed %q should omit the mempool link when there is no tx hash", content)
 	}
 }
 
@@ -267,7 +214,7 @@ func TestCallSwapPayoutWebhook_VaultBalance_AppendsFieldWithBtc(t *testing.T) {
 
 	content := embedText(t, gotBody)
 	// 28768896 sats / 1e8 = 0.28768896 BTC, trailing zeros trimmed.
-	for _, want := range []string{"Vault balance", "28768896 sats", "0.28768896 BTC"} {
+	for _, want := range []string{"Vault", "0.28768896 ₿"} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("webhook embed %q missing %q", content, want)
 		}
@@ -288,7 +235,7 @@ func TestCallSwapPayoutWebhook_NoVaultBalance_OmitsField(t *testing.T) {
 		BtcAmount: "95000",
 	})
 
-	if strings.Contains(embedText(t, gotBody), "Vault balance") {
+	if strings.Contains(embedText(t, gotBody), "Vault") {
 		t.Fatalf("webhook embed should omit the vault-balance field: %s", gotBody)
 	}
 }

--- a/internal/utils/webhook/webhook_test.go
+++ b/internal/utils/webhook/webhook_test.go
@@ -239,3 +239,43 @@ func TestCallSwapPayoutWebhook_NoVaultBalance_OmitsField(t *testing.T) {
 		t.Fatalf("webhook embed should omit the vault-balance field: %s", gotBody)
 	}
 }
+
+func TestFormatUnits_ThousandsSeparators(t *testing.T) {
+	cases := []struct{ raw string; dec int; want string }{
+		{"2000000000000000000000", 18, "2,000"},
+		{"1234567000000000000000000", 18, "1,234,567"},
+		{"999000000000000000000", 18, "999"},
+		{"123456789", 8, "1.23456789"},
+		{"-50", 8, "-0.0000005"},
+	}
+	for _, c := range cases {
+		if got := formatUnits(c.raw, c.dec); got != c.want {
+			t.Fatalf("formatUnits(%q,%d) = %q, want %q", c.raw, c.dec, got, c.want)
+		}
+	}
+}
+
+func TestCallSwapPayoutWebhook_ShowsSwapperWallet(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	newTestClient(t).CallSwapPayoutWebhook(context.Background(), srv.URL, SwapPayoutEvent{
+		Status:      "completed",
+		IcyAmount:   "2000000000000000000000",
+		BtcAmount:   "123900",
+		FromAddress: "0x1234567890abcdef1234567890abcdef12345678",
+		BtcAddress:  "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+		BtcTxHash:   "abc",
+	})
+	content := embedText(t, gotBody)
+	// commas on ICY, truncated EVM wallet, basescan link, truncated BTC dest.
+	for _, want := range []string{"2,000", "0x123456", "basescan.org/address/0x1234567890abcdef", "bc1qar0"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("embed %q missing %q", content, want)
+		}
+	}
+}


### PR DESCRIPTION
Per operator request: notify on completed swaps only (status gate in one place; failed/needs_reconcile/pending fire nothing, swap-detected emit removed), a compact embed (3 inline fields + one description line for destination/tx, no thumbnail), orange-circle title emoji + Bitcoin-orange border. Tests updated to match (failure + detected paths assert no webhook). Webhook + server suites green, vet clean.