### PR TITLE
fix(btcrpc): verify unconfirmed UTXO is treasury self-change

### DIFF
--- a/docs/verification/custody-caps.md
+++ b/docs/verification/custody-caps.md
@@ -362,3 +362,22 @@ Additive, no migration, no new config/columns/statuses. Reverting this change
 restores the prior (single-process-only) daily-cap behaviour. The advisory lock is
 purely a runtime coordination primitive; `pg_advisory_lock`s auto-release when a
 session ends, so nothing is left held after a rollback or a crash.
+
+---
+
+## Addendum, unconfirmed self-change verification (2026-07-21)
+
+The 2026-07-20 fix that let a payout chain onto the treasury's unconfirmed
+self-change (to avoid stranding liquidity between back-to-back swaps) originally
+trusted ANY unconfirmed UTXO at the treasury address as self-change. A security
+review flagged the transaction-pinning risk: anyone can pay the public treasury
+address, so a stranger's unconfirmed (RBF-replaceable, possibly-never-confirming)
+tx could get chained onto.
+
+Fixed: an unconfirmed UTXO is now spendable only if its funding tx has the
+treasury address among its INPUTS (`btcrpc.isSelfChange`), i.e. it is a tx the
+treasury itself sent. A tx that merely pays the treasury has it only as an
+output and is dropped. A lookup failure fails closed (the UTXO is not spent).
+Verified via the new `blockstream.GetTransaction`; confirmed UTXOs are unaffected.
+Tests: `TestFilterSpendableUTXOs_SelfChangeVsStrangerDeposit`,
+`..._LookupErrorFailsClosed`, `TestIsSelfChange_NilOrNoMatch`.

--- a/internal/btcrpc/blockstream/blockstream.go
+++ b/internal/btcrpc/blockstream/blockstream.go
@@ -369,6 +369,34 @@ func (c *blockstream) GetTransactionConfirmations(txID string) (int64, error) {
 	return tip - blockHeight + 1, nil
 }
 
+// GetTransaction reads /tx/:txid and returns the full transaction, or (nil, nil)
+// if the node does not know it (404). Endpoint failover is handled one level up
+// by BtcRpc.withRetry, so this is single-shot.
+func (c *blockstream) GetTransaction(txID string) (*Transaction, error) {
+	url := fmt.Sprintf("%s/tx/%s", c.baseURL, txID)
+	resp, err := c.client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("get tx %s: %w", txID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get tx %s: unexpected status code %d", txID, resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("get tx %s: read body: %w", txID, err)
+	}
+	var tx Transaction
+	if err := json.Unmarshal(body, &tx); err != nil {
+		return nil, fmt.Errorf("get tx %s: parse body: %w", txID, err)
+	}
+	return &tx, nil
+}
+
 func (c *blockstream) GetUTXOs(address string) ([]UTXO, error) {
 	url := fmt.Sprintf("%s/address/%s/utxo", c.baseURL, address)
 	var lastErr error

--- a/internal/btcrpc/blockstream/interface.go
+++ b/internal/btcrpc/blockstream/interface.go
@@ -37,4 +37,9 @@ type IBlockStream interface {
 	// confirm-before-complete sweep to decide when an outgoing payout is safe to
 	// mark completed.
 	GetTransactionConfirmations(txID string) (int64, error)
+	// GetTransaction returns the full transaction (including its inputs) for txID,
+	// or (nil, nil) if the node does not know it. Used to verify that an
+	// unconfirmed treasury UTXO is the treasury's OWN change (the treasury is
+	// among the tx inputs) before a payout is allowed to chain onto it.
+	GetTransaction(txID string) (*Transaction, error)
 }

--- a/internal/btcrpc/hardening_test.go
+++ b/internal/btcrpc/hardening_test.go
@@ -150,3 +150,69 @@ func TestSelection_InsufficientConfirmed_ChainsUnconfirmed(t *testing.T) {
 		t.Fatal("first selected UTXO is unconfirmed; confirmed funds must be preferred")
 	}
 }
+
+// unconfirmed self-change (treasury is an input) is kept; a stranger's
+// unconfirmed deposit (treasury only an output) is dropped; confirmed is always
+// kept. This is the transaction-pinning guard.
+func TestFilterSpendableUTXOs_SelfChangeVsStrangerDeposit(t *testing.T) {
+	const treasury = "bc1qtreasury"
+	uConfirmed := blockstream.UTXO{TxID: "conf"}
+	uConfirmed.Status.Confirmed = true
+	uSelf := blockstream.UTXO{TxID: "self"}   // unconfirmed, our own change
+	uOther := blockstream.UTXO{TxID: "other"} // unconfirmed, stranger's deposit
+
+	txByID := map[string]*blockstream.Transaction{
+		// our own spend: treasury is among the inputs
+		"self": {Vin: []blockstream.Input{{Prevout: &blockstream.Output{ScriptPubKeyAddress: treasury}}}},
+		// stranger paying us: treasury only appears as an output, never an input
+		"other": {
+			Vin:  []blockstream.Input{{Prevout: &blockstream.Output{ScriptPubKeyAddress: "bc1qstranger"}}},
+			Vout: []blockstream.Output{{ScriptPubKeyAddress: treasury}},
+		},
+	}
+	getTx := func(id string) (*blockstream.Transaction, error) { return txByID[id], nil }
+
+	got, err := filterSpendableUTXOs([]blockstream.UTXO{uConfirmed, uSelf, uOther}, treasury, getTx)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	kept := map[string]bool{}
+	for _, u := range got {
+		kept[u.TxID] = true
+	}
+	if !kept["conf"] || !kept["self"] {
+		t.Fatalf("confirmed + self-change must be kept, got %v", kept)
+	}
+	if kept["other"] {
+		t.Fatal("stranger's unconfirmed deposit must be dropped (pinning guard)")
+	}
+}
+
+// A lookup failure on an unconfirmed UTXO fails closed: the whole selection
+// errors rather than spending an unverified UTXO.
+func TestFilterSpendableUTXOs_LookupErrorFailsClosed(t *testing.T) {
+	u := blockstream.UTXO{TxID: "x"} // unconfirmed
+	getTx := func(string) (*blockstream.Transaction, error) {
+		return nil, errTest
+	}
+	if _, err := filterSpendableUTXOs([]blockstream.UTXO{u}, "bc1qtreasury", getTx); err == nil {
+		t.Fatal("expected a fail-closed error when the tx lookup fails")
+	}
+}
+
+// A tx the node does not know (nil) is not provably self-change, so it is dropped.
+func TestIsSelfChange_NilOrNoMatch(t *testing.T) {
+	if isSelfChange(nil, "bc1qtreasury") {
+		t.Fatal("nil tx is not self-change")
+	}
+	tx := &blockstream.Transaction{Vin: []blockstream.Input{{Prevout: &blockstream.Output{ScriptPubKeyAddress: "bc1qother"}}}}
+	if isSelfChange(tx, "bc1qtreasury") {
+		t.Fatal("a tx with no treasury input is not self-change")
+	}
+}
+
+var errTest = fmtError("lookup failed")
+
+type fmtError string
+
+func (e fmtError) Error() string { return string(e) }

--- a/internal/btcrpc/helper.go
+++ b/internal/btcrpc/helper.go
@@ -286,14 +286,54 @@ func (b *BtcRpc) verifyAndSelectUTXOs(address string, amountToSend, txFee int64)
 	return nil, false
 }
 
-// orderSpendableUTXOs returns the treasury's own UTXOs in SELECTION order:
+// isSelfChange reports whether tx is one the TREASURY itself sent, i.e. the
+// treasury address is among the tx's inputs. Its change output paying back to
+// the treasury is then genuine self-change, safe to chain a new payout onto.
+//
+// A transaction that merely PAYS the treasury (anyone can send to the public
+// address) has the treasury only as an OUTPUT, not an input, and returns false.
+// This is the guard against transaction-pinning: without it, a stranger could
+// send dust to the treasury address and a payout would chain onto that
+// unconfirmed, possibly-never-confirming (or RBF-replaceable) third-party tx.
+func isSelfChange(tx *blockstream.Transaction, treasury string) bool {
+	if tx == nil {
+		return false
+	}
+	for _, in := range tx.Vin {
+		if in.Prevout != nil && in.Prevout.ScriptPubKeyAddress == treasury {
+			return true
+		}
+	}
+	return false
+}
+
+// filterSpendableUTXOs keeps every confirmed UTXO and only those UNCONFIRMED
+// UTXOs that are the treasury's own change (verified via getTx + isSelfChange).
+// A lookup error is propagated (fail-closed: never spend an unverified UTXO). The
+// getTx indirection keeps this pure and unit-testable without a live node.
+func filterSpendableUTXOs(utxos []blockstream.UTXO, treasury string, getTx func(txID string) (*blockstream.Transaction, error)) ([]blockstream.UTXO, error) {
+	out := make([]blockstream.UTXO, 0, len(utxos))
+	for _, u := range utxos {
+		if u.Status.Confirmed {
+			out = append(out, u)
+			continue
+		}
+		tx, err := getTx(u.TxID)
+		if err != nil {
+			return nil, err
+		}
+		if isSelfChange(tx, treasury) {
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}
+
+// orderSpendableUTXOs returns the treasury's spendable UTXOs in SELECTION order:
 // confirmed first (value desc), then unconfirmed (value desc).
 //
-// Every UTXO passed here was returned by GetUTXOs(treasuryAddress), i.e. the
-// esplora/mempool `/address/{addr}/utxo` set for the treasury's OWN address, so
-// an unconfirmed entry is by construction a change output paying back to the
-// treasury (self-change from a not-yet-confirmed prior payout). That is why no
-// per-UTXO address field is needed: the query address IS the ownership proof.
+// The unconfirmed entries here have already been verified as treasury
+// self-change by filterSpendableUTXOs, so chaining onto them is safe.
 //
 // Confirmed-first ordering makes the greedy selector spend confirmed funds first
 // and only chain onto unconfirmed self-change when confirmed funds cannot cover
@@ -323,8 +363,15 @@ func orderSpendableUTXOs(utxos []blockstream.UTXO) []blockstream.UTXO {
 func (b *BtcRpc) getSpendableUTXOs(address string) ([]blockstream.UTXO, error) {
 	var utxos []blockstream.UTXO
 	err := b.withRetry(func(bs blockstream.IBlockStream) error {
-		var err error
-		utxos, err = bs.GetUTXOs(address)
+		raw, err := bs.GetUTXOs(address)
+		if err != nil {
+			return err
+		}
+		// Keep confirmed funds, plus only unconfirmed UTXOs proven to be the
+		// treasury's own change (guards against chaining onto a stranger's
+		// unconfirmed deposit). Verified against the SAME endpoint we fetched
+		// the UTXO set from.
+		utxos, err = filterSpendableUTXOs(raw, address, bs.GetTransaction)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
Closes the transaction-pinning finding from the 2026-07-21 security review. The earlier unconfirmed-chaining fix trusted any unconfirmed UTXO at the (public) treasury address as self-change; a stranger could plant an unconfirmed RBF-replaceable tx and a payout would chain onto it. Now an unconfirmed UTXO is spendable only if its funding tx has the treasury among its inputs (a tx the treasury itself sent); a payment TO the treasury has it only as an output and is dropped, and a lookup failure fails closed. Verification stays inside btcrpc via a new blockstream.GetTransaction (no store coupling, no Send signature change). Tests: self-change kept / stranger-deposit dropped / fail-closed. btcrpc + server suites green, vet clean.